### PR TITLE
rename JwsVerificationKey2020 to JsonWebKey2020

### DIFF
--- a/index.html
+++ b/index.html
@@ -850,9 +850,9 @@ consultation with the entry maintainer.
       <h3><dfn data-lt="JwsVerificationKey2020" data-dfn-type="dfn" id="JwsVerificationKey2020">JwsVerificationKey2020</dfn></h3>
 
       <p>A JWK publicKey.</p>
-
-      <p class="issue" data-number="240">
-The duplication and/or possible interaction of properties held in a JWK and a verification method are an active topic of discussion in the Working Group. Implementers are cautioned that the behavior of values associated with this property are not stable and might change in the future.
+      
+      <p class="warning">
+This key type has been deprecated in favor of JsonWebKey2020.
 </p>
 
 
@@ -884,6 +884,55 @@ The duplication and/or possible interaction of properties held in a JWK and a ve
           <tr>
             <td>
               <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/JwsVerificationKey2020.json">JSON Schema</a>
+            </td>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>
+            </td>
+            <td>
+              CBOR
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h3><dfn data-lt="JsonWebKey2020" data-dfn-type="dfn" id="JsonWebKey2020">JsonWebKey2020</dfn></h3>
+
+      <p>A JWK publicKey.</p>
+
+      <p class="issue" data-number="240">
+The duplication and/or possible interaction of properties held in a JWK and a verification method are an active topic of discussion in the Working Group. Implementers are cautioned that the behavior of values associated with this property are not stable and might change in the future.
+      </p>
+
+      <pre class="example">
+{
+  "id": "did:example:123#_TKzHv2jFIyvdTGF1Dsgwngfdg3SH6TpDv0Ta1aOEkw",
+  "type": "JsonWebKey2020",
+  "controller": "did:example:123",
+  "publicKeyJwk": {
+    "crv": "P-256",
+    "x": "38M1FDts7Oea7urmseiugGW7tWc3mLpJh6rKe7xINZ8",
+    "y": "nDQW6XZ7b_u2Sy9slofYLlG03sOEoug3I0aAPQ0exs4",
+    "kty": "EC",
+    "kid": "_TKzHv2jFIyvdTGF1Dsgwngfdg3SH6TpDv0Ta1aOEkw"
+  }
+}
+      </pre>
+
+      <h4>Definitions</h4>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>JSON Schema</th>
+            <th>JSON-LD</th>
+            <th>CBOR</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c.github.io/did-core-registries/schemas/publicKey/JsonWebKey2020.json">JSON Schema</a>
             </td>
             <td>
               <a href="https://w3c.github.io/did-core-registries/contexts/did-v1.jsonld">JSON-LD</a>

--- a/schemas/publicKey/JsonWebKey2020.js
+++ b/schemas/publicKey/JsonWebKey2020.js
@@ -1,0 +1,50 @@
+const { ajv, schemas } = require("../index");
+
+describe("/did-core.publicKey.JsonWebKey2020", () => {
+  it("type must be JsonWebKey2020", () => {
+    const validExample = {
+      id: "did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q",
+      type: "JsonWebKey2020",
+      controller: "did:example:123",
+      publicKeyJwk: {
+        crv: "secp256k1",
+        x: "NtngWpJUr-rlNNbs0u-Aa8e16OwSJu6UiFf0Rdo1oJ4",
+        y: "qN1jKupJlFsPFc1UkWinqljv4YE0mq_Ickwnjgasvmo",
+        kty: "EC",
+        kid: "WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q"
+      }
+    };
+    let valid = ajv.validate(
+      schemas["/did-core.publicKey.JsonWebKey2020"],
+      validExample
+    );
+    expect(valid).toBe(true);
+    valid = ajv.validate(
+      schemas["/did-core.publicKey.JsonWebKey2020"],
+      {
+        ...validExample,
+        type: "Secp256k1VerificationKey2018"
+      }
+    );
+    expect(valid).toBe(false);
+  });
+
+  it("publicKeyJwk is valid", () => {
+    let valid = ajv.validate(
+      schemas["/did-core.publicKey.JsonWebKey2020"],
+      {
+        id: "did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q",
+        type: "JsonWebKey2020",
+        controller: "did:example:123",
+        publicKeyJwk: {
+          crv: "secp256k1",
+          x: "NtngWpJUr-rlNNbs0u-Aa8e16OwSJu6UiFf0Rdo1oJ4",
+          y: "qN1jKupJlFsPFc1UkWinqljv4YE0mq_Ickwnjgasvmo",
+          kty: "EC",
+          kid: "WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q"
+        }
+      }
+    );
+    expect(valid).toBe(true);
+  });
+});

--- a/schemas/publicKey/JsonWebKey2020.json
+++ b/schemas/publicKey/JsonWebKey2020.json
@@ -1,0 +1,41 @@
+{
+  "$id": "/did-core.publicKey.JsonWebKey2020",
+  "type": "object",
+  "title": "JsonWebKey2020",
+  "description": "https://w3c.github.io/did-core-registries/#JsonWebKey2020",
+  "properties": {
+    "id": {
+      "title": "Public Key ID",
+      "type": "string",
+      "example": ["did:example:123#JUvpllMEYUZ2joO59UNui_XYDqxVqiFLLAJ8klWuPBw"]
+    },
+    "type": {
+      "title": "Public Key Type",
+      "type": "string",
+      "enum": ["JsonWebKey2020"],
+      "example": ["JsonWebKey2020"]
+    },
+    "controller": {
+      "title": "Controller",
+      "description": "https://w3c.github.io/did-core-registries/#controller",
+      "type": "string",
+      "example": ["did:example:123"]
+    },
+    "publicKeyJwk": {
+      "title": "Public Key JWK",
+      "description": "https://w3c.github.io/did-core-registries/#publicKeyJwk",
+      "type": "object",
+      "example": [
+        {
+          "crv": "secp256k1",
+          "kid": "JUvpllMEYUZ2joO59UNui_XYDqxVqiFLLAJ8klWuPBw",
+          "kty": "EC",
+          "x": "dWCvM4fTdeM0KmloF57zxtBPXTOythHPMm1HCLrdd3A",
+          "y": "36uMVGM7hnw-N6GnjFcihWE3SkrhMLzzLCdPMXPEXlA"
+        }
+      ]
+    }
+  },
+  "required": ["id", "type", "controller", "publicKeyJwk"],
+  "additionalProperties": false
+}

--- a/schemas/publicKey/publicKey.json
+++ b/schemas/publicKey/publicKey.json
@@ -6,6 +6,7 @@
   "oneOf": [
     { "$ref": "did-core.publicKey.Ed25519VerificationKey2018" },
     { "$ref": "did-core.publicKey.EcdsaSecp256k1VerificationKey2019" },
+    { "$ref": "did-core.publicKey.JsonWebKey2020" },
     { "$ref": "did-core.publicKey.JwsVerificationKey2020" },
     { "$ref": "did-core.publicKey.X25519KeyAgreementKey2019" }
   ]

--- a/test-dids/did:web:vc.transmute.world.json
+++ b/test-dids/did:web:vc.transmute.world.json
@@ -77,6 +77,76 @@
         "kty": "EC",
         "kid": "NjQ6Y_ZMj6IUK_XkgCDwtKHlNTUTVjEYOWZtxhp1n-E"
       }
+    },
+    {
+      "id": "did:web:vc.transmute.world#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:vc.transmute.world",
+      "publicKeyJwk": {
+        "crv": "Ed25519",
+        "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
+        "kty": "OKP",
+        "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
+      }
+    },
+    {
+      "id": "did:web:vc.transmute.world#4SZ-StXrp5Yd4_4rxHVTCYTHyt4zyPfN1fIuYsm6k3A",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:vc.transmute.world",
+      "publicKeyJwk": {
+        "crv": "secp256k1",
+        "x": "Z4Y3NNOxv0J6tCgqOBFnHnaZhJF6LdulT7z8A-2D5_8",
+        "y": "i5a2NtJoUKXkLm6q8nOEu9WOkso1Ag6FTUT6k_LMnGk",
+        "kty": "EC",
+        "kid": "4SZ-StXrp5Yd4_4rxHVTCYTHyt4zyPfN1fIuYsm6k3A"
+      }
+    },
+    {
+      "id": "did:web:vc.transmute.world#n4cQ-I_WkHMcwXBJa7IHkYu8CMfdNcZKnKsOrnHLpFs",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:vc.transmute.world",
+      "publicKeyJwk": {
+        "e": "AQAB",
+        "n": "omwsC1AqEk6whvxyOltCFWheSQvv1MExu5RLCMT4jVk9khJKv8JeMXWe3bWHatjPskdf2dlaGkW5QjtOnUKL742mvr4tCldKS3ULIaT1hJInMHHxj2gcubO6eEegACQ4QSu9LO0H-LM_L3DsRABB7Qja8HecpyuspW1Tu_DbqxcSnwendamwL52V17eKhlO4uXwv2HFlxufFHM0KmCJujIKyAxjD_m3q__IiHUVHD1tDIEvLPhG9Azsn3j95d-saIgZzPLhQFiKluGvsjrSkYU5pXVWIsV-B2jtLeeLC14XcYxWDUJ0qVopxkBvdlERcNtgF4dvW4X00EHj4vCljFw",
+        "kty": "RSA",
+        "kid": "n4cQ-I_WkHMcwXBJa7IHkYu8CMfdNcZKnKsOrnHLpFs"
+      }
+    },
+    {
+      "id": "did:web:vc.transmute.world#_TKzHv2jFIyvdTGF1Dsgwngfdg3SH6TpDv0Ta1aOEkw",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:vc.transmute.world",
+      "publicKeyJwk": {
+        "crv": "P-256",
+        "x": "38M1FDts7Oea7urmseiugGW7tWc3mLpJh6rKe7xINZ8",
+        "y": "nDQW6XZ7b_u2Sy9slofYLlG03sOEoug3I0aAPQ0exs4",
+        "kty": "EC",
+        "kid": "_TKzHv2jFIyvdTGF1Dsgwngfdg3SH6TpDv0Ta1aOEkw"
+      }
+    },
+    {
+      "id": "did:web:vc.transmute.world#8wgRfY3sWmzoeAL-78-oALNvNj67ZlQxd1ss_NX1hZY",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:vc.transmute.world",
+      "publicKeyJwk": {
+        "crv": "P-384",
+        "x": "GnLl6mDti7a2VUIZP5w6pcRX8q5nvEIgB3Q_5RI2p9F_QVsaAlDN7IG68Jn0dS_F",
+        "y": "jq4QoAHKiIzezDp88s_cxSPXtuXYFliuCGndgU4Qp8l91xzD1spCmFIzQgVjqvcP",
+        "kty": "EC",
+        "kid": "8wgRfY3sWmzoeAL-78-oALNvNj67ZlQxd1ss_NX1hZY"
+      }
+    },
+    {
+      "id": "did:web:vc.transmute.world#NjQ6Y_ZMj6IUK_XkgCDwtKHlNTUTVjEYOWZtxhp1n-E",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:vc.transmute.world",
+      "publicKeyJwk": {
+        "crv": "P-521",
+        "x": "AVlZG23LyXYwlbjbGPMxZbHmJpDSu-IvpuKigEN2pzgWtSo--Rwd-n78nrWnZzeDc187Ln3qHlw5LRGrX4qgLQ-y",
+        "y": "ANIbFeRdPHf1WYMCUjcPz-ZhecZFybOqLIJjVOlLETH7uPlyG0gEoMWnIZXhQVypPy_HtUiUzdnSEPAylYhHBTX2",
+        "kty": "EC",
+        "kid": "NjQ6Y_ZMj6IUK_XkgCDwtKHlNTUTVjEYOWZtxhp1n-E"
+      }
     }
   ]
 }


### PR DESCRIPTION
Signed-off-by: Kyle Den Hartog <kyle.denhartog@mattr.global>

Updates the name in alignment with this PR [#14](https://github.com/w3c-ccg/lds-jws2020/pull/14) in the suite


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kdenhartog/did-core-registries/pull/43.html" title="Last updated on May 6, 2020, 7:45 AM UTC (342a6d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core-registries/43/46b7cb4...kdenhartog:342a6d5.html" title="Last updated on May 6, 2020, 7:45 AM UTC (342a6d5)">Diff</a>