### PR TITLE
Fix link to issue 240

### DIFF
--- a/index.html
+++ b/index.html
@@ -1052,8 +1052,8 @@ for the value of <code>type</code> in a verification method object.
       <section>
         <h4><dfn data-lt="JwsVerificationKey2020" data-dfn-type="dfn" id="JwsVerificationKey2020">JwsVerificationKey2020</dfn></h4>
 
-        <p class="issue" data-number="240">
-The duplication and/or possible interaction of properties held in a JWK and a verification method are an active topic of discussion in the Working Group. Implementers are cautioned that the behavior of values associated with this property are not stable and might change in the future.
+        <p class="issue">
+<a href="https://github.com/w3c/did-core/issues/240">ISSUE 240 on DID Core</a>: The duplication and/or possible interaction of properties held in a JWK and a verification method are an active topic of discussion in the Working Group. Implementers are cautioned that the behavior of values associated with this property are not stable and might change in the future.
         </p>
 
         <table class="simple" style="width: 100%;">


### PR DESCRIPTION
respec was linking it to this repo but it's an issue on did-core


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/50.html" title="Last updated on Jun 2, 2020, 6:26 AM UTC (ce0def5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/50/201cbf8...ce0def5.html" title="Last updated on Jun 2, 2020, 6:26 AM UTC (ce0def5)">Diff</a>