### PR TITLE
added `blockchainAccountId` to core context

### DIFF
--- a/contexts/did-v1.jsonld
+++ b/contexts/did-v1.jsonld
@@ -42,6 +42,7 @@
       "@id": "dc:created",
       "@type": "xsd:dateTime"
     },
+    "ethereumAddress": "sec:ethereumAddress",
     "keyAgreement": {
       "@id": "sec:keyAgreementMethod",
       "@type": "@id",

--- a/contexts/did-v1.jsonld
+++ b/contexts/did-v1.jsonld
@@ -42,7 +42,7 @@
       "@id": "dc:created",
       "@type": "xsd:dateTime"
     },
-    "ethereumAddress": "sec:ethereumAddress",
+    "blockchainAccountId": "sec:blockchainAccountId",
     "keyAgreement": {
       "@id": "sec:keyAgreementMethod",
       "@type": "@id",


### PR DESCRIPTION
fixes https://github.com/w3c/did-core/issues/55; added `ethereumAddress` to core context