### PR TITLE
Limit JSON Schema requirement to properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@ feature to eliminate the possibility of term conflicts.
         </ul>
       </li>
       <li>
-Any addition to the DID Core Registries MUST specify a non-normative JSON Schema
+Any addition to the DID Core Registries that is a property MUST specify a non-normative JSON Schema
 (the defining specification is normative) for the addition.
       </li>
       <li>


### PR DESCRIPTION
Parameters and values don't need a JSON Schema I think?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/84.html" title="Last updated on Jul 10, 2020, 11:43 AM UTC (ca35b09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/84/825af5a...ca35b09.html" title="Last updated on Jul 10, 2020, 11:43 AM UTC (ca35b09)">Diff</a>