### PR TITLE
Add initial-state and transform-keys DID parameters. Fixes #30.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1722,9 +1722,49 @@ did:example:123?version-time=2016-10-17T02:41:00Z
       </pre>
     </section>
 
-    <p class="issue" data-number="30">
-      Example needed.
-    </p>
+    <section>
+      <h4><dfn data-lt="initial-state" data-dfn-type="dfn" id="initial-state">initial-state</dfn></h4>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://github.com/decentralized-identity/did-spec-extensions/blob/master/parameters/initial-state.md">DID Spec Extensions by DIF</a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <pre class="example" title="Example of initial-state parameter">
+did:example:123?initial-state=eyJkZWx0YV9oYXNoIjoiRWlDUlRKZ2Q0U0V2YUZDLW9fNUZjQnZJUkRtWF94Z3RLX3g...
+      </pre>
+    </section>
+
+    <section>
+      <h4><dfn data-lt="transform-keys" data-dfn-type="dfn" id="transform-keys">transform-keys</dfn></h4>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://github.com/decentralized-identity/did-spec-extensions/blob/master/parameters/transform-keys.md">DID Spec Extensions by DIF</a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <pre class="example" title="Example of transform-keys parameter">
+did:example:123?transform-keys=jwk
+      </pre>
+    </section>
 
   </section>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-spec-registries/pull/85.html" title="Last updated on Jul 10, 2020, 12:43 PM UTC (aa5521b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/85/825af5a...peacekeeper:aa5521b.html" title="Last updated on Jul 10, 2020, 12:43 PM UTC (aa5521b)">Diff</a>