### PR TITLE
Remove json schema requirement for registries

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,10 +199,6 @@ feature to eliminate the possibility of term conflicts.
         </ul>
       </li>
       <li>
-Any addition to the DID Core Registries MUST specify a non-normative JSON Schema
-(the defining specification is normative) for the addition.
-      </li>
-      <li>
 Properties in the DID Core Registries MUST NOT be removed, only deprecated.
       </li>
     </ol>
@@ -252,7 +248,6 @@ useful to all DID methods.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -261,9 +256,6 @@ useful to all DID methods.
             <tr>
               <td>
                 <a href="https://www.w3.org/TR/did-core/#production-0">DID Core</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -293,7 +285,6 @@ useful to all DID methods.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -302,9 +293,6 @@ useful to all DID methods.
             <tr>
               <td>
                 <a href="https://www.w3.org/TR/did-core/#did-subject">DID Core</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -330,7 +318,6 @@ useful to all DID methods.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -339,9 +326,6 @@ useful to all DID methods.
             <tr>
               <td>
                 <a href="https://www.w3.org/TR/did-core/#authorization-and-delegation">DID Core</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -368,7 +352,6 @@ useful to all DID methods.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -403,7 +386,6 @@ DID Core. See <a href="https://github.com/w3c/did-core/issues/283">issue
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -412,9 +394,6 @@ DID Core. See <a href="https://github.com/w3c/did-core/issues/283">issue
             <tr>
               <td>
                 <a href="https://www.w3.org/TR/did-core/#dfn-publickey">DID Core</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -458,7 +437,6 @@ DID Core. See <a href="https://github.com/w3c/did-core/issues/283">issue
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -468,9 +446,7 @@ DID Core. See <a href="https://github.com/w3c/did-core/issues/283">issue
               <td>
                 <a href="https://www.w3.org/TR/did-core/#service-endpoints">DID Core</a>
               </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
-              </td>
+
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
               </td>
@@ -504,7 +480,6 @@ Subject to removal from DID Core - see
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -541,7 +516,6 @@ These terms are properties or types belonging to objects in the value of
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -551,9 +525,7 @@ These terms are properties or types belonging to objects in the value of
               <td>
                 <a href="https://www.w3.org/TR/did-core/#service-endpoints">DID Core</a>
               </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
-              </td>
+
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
               </td>
@@ -592,7 +564,6 @@ verification relationship</a>.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -601,9 +572,6 @@ verification relationship</a>.
             <tr>
               <td>
                 <a href="https://w3id.org/security/#assertionMethod">security-vocab</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -648,7 +616,6 @@ verification relationship</a>.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -657,9 +624,6 @@ verification relationship</a>.
             <tr>
               <td>
                 <a href="https://www.w3.org/TR/did-core/#authentication">DID Core</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -704,7 +668,6 @@ verification relationship</a>.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -713,9 +676,6 @@ verification relationship</a>.
             <tr>
               <td>
                 <a href="https://w3id.org/security/#capabilityDelegation">security-vocab</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -758,7 +718,6 @@ verification relationship</a>.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -767,9 +726,6 @@ verification relationship</a>.
             <tr>
               <td>
                 <a href="https://w3id.org/security/#capabilityInvocation">security-vocab</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -814,7 +770,6 @@ verification relationship</a>.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -823,9 +778,6 @@ verification relationship</a>.
             <tr>
               <td>
                 <a href="https://w3id.org/security/#keyAgreement">security-vocab</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/publicKey/publicKey.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -863,7 +815,6 @@ These properties are for use on a verification method object, not on the DID doc
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -906,7 +857,6 @@ These properties are for use on a verification method object, not on the DID doc
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -950,7 +900,6 @@ These properties are for use on a verification method object, not on the DID doc
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -993,7 +942,6 @@ These properties are for use on a verification method object, not on the DID doc
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1023,7 +971,6 @@ These properties are for use on a verification method object, not on the DID doc
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1064,7 +1011,6 @@ for the value of <code>type</code> in a verification method object.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1073,9 +1019,6 @@ for the value of <code>type</code> in a verification method object.
             <tr>
               <td>
                 <span class="issue">Normative definition pending</span>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/publicKey/JwsVerificationKey2020.json">JSON Schema</a>
               </td>
               <td>
               </td>
@@ -1107,7 +1050,6 @@ for the value of <code>type</code> in a verification method object.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1116,9 +1058,6 @@ for the value of <code>type</code> in a verification method object.
             <tr>
               <td>
                 <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Ecdsa Secp256k1 Signature 2019</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/publicKey/EcdsaSecp256k1VerificationKey2019.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -1152,7 +1091,6 @@ for the value of <code>type</code> in a verification method object.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1161,9 +1099,6 @@ for the value of <code>type</code> in a verification method object.
             <tr>
               <td>
                 <a href="https://w3c-ccg.github.io/lds-ed25519-2018/">Ed25519 Signature 2018</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/publicKey/Ed25519VerificationKey2018.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -1194,7 +1129,6 @@ for the value of <code>type</code> in a verification method object.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1240,7 +1174,6 @@ for the value of <code>type</code> in a verification method object.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1277,7 +1210,6 @@ for the value of <code>type</code> in a verification method object.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1319,7 +1251,6 @@ for the value of <code>type</code> in a verification method object.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1348,7 +1279,6 @@ for the value of <code>type</code> in a verification method object.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1417,7 +1347,6 @@ These properties contain information pertaining to the DID resolution request.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1449,7 +1378,6 @@ These properties contain information pertaining to the DID resolution response.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1475,7 +1403,6 @@ These properties contain information pertaining to the DID resolution response.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1501,7 +1428,6 @@ These properties contain information pertaining to the DID resolution response.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1527,7 +1453,6 @@ These properties contain information pertaining to the DID resolution response.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1560,7 +1485,7 @@ rather than the DID subject.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
+
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1569,9 +1494,6 @@ rather than the DID subject.
             <tr>
               <td>
                 <a href="https://www.w3.org/TR/did-core/#created">DID Core</a>
-              </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -1596,7 +1518,6 @@ rather than the DID subject.
           <thead>
             <tr>
               <th>Normative Definition</th>
-              <th>JSON Schema</th>
               <th>JSON-LD</th>
               <th>CBOR</th>
             </tr>
@@ -1606,9 +1527,7 @@ rather than the DID subject.
               <td>
                 <a href="https://www.w3.org/TR/did-core/#updated">DID Core</a>
               </td>
-              <td>
-                <a href="https://w3c.github.io/did-spec-registries/schemas/didDocument/didDocument.json">JSON Schema</a>
-              </td>
+
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
               </td>


### PR DESCRIPTION
This will allow for people to register extensions and core properties easier, and greatly simplifies the registry... we have also seen exactly 0 contribution to JSON Schemas, and they are not required in any way.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/88.html" title="Last updated on Jul 14, 2020, 3:04 PM UTC (3ce075e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/88/8b047ef...3ce075e.html" title="Last updated on Jul 14, 2020, 3:04 PM UTC (3ce075e)">Diff</a>