### PR TITLE
Change "resolution options" to "resolution input metadata"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1406,7 +1406,7 @@ for the value of <code>type</code> in a verification method object.
     </section>
 
     <section>
-      <h3>DID resolution options</h3>
+      <h3>DID resolution input metadata</h3>
       <p>
 These properties contain information pertaining to the DID resolution request.
       </p>


### PR DESCRIPTION
This is the term now used in DID Core, see https://w3c.github.io/did-core/#did-resolution-input-metadata-properties


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/89.html" title="Last updated on Jul 16, 2020, 10:26 PM UTC (a2c25b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/89/5546192...a2c25b4.html" title="Last updated on Jul 16, 2020, 10:26 PM UTC (a2c25b4)">Diff</a>