### PR TITLE
Add X25519KeyAgreementKey2019 to did-v1.jsonld

### DIFF
--- a/contexts/did-v1.jsonld
+++ b/contexts/did-v1.jsonld
@@ -13,6 +13,7 @@
     "Ed25519VerificationKey2018": "sec:Ed25519VerificationKey2018",
     "RsaVerificationKey2018": "sec:RsaVerificationKey2018",
     "SchnorrSecp256k1VerificationKey2019": "sec:SchnorrSecp256k1VerificationKey2019",
+    "X25519KeyAgreementKey2019": "sec:X25519KeyAgreementKey2019",
     "ServiceEndpointProxyService": "didv:ServiceEndpointProxyService",
     "assertionMethod": {
       "@id": "sec:assertionMethod",


### PR DESCRIPTION

I didn't create this name, so I'm not going to ask it be changed... but its a bit redundant...

> The original Curve25519 paper defined it as a Diffie–Hellman (DH) function. Daniel J. Bernstein has since proposed that the name Curve25519 be used for the underlying curve, and the name X25519 for the DH function.[3]

https://en.wikipedia.org/wiki/Curve25519

Consider the alternative:

```
{
  type: 'JsonWebKey2020',
  id: '#z6LSnjagzhe8Df6gZmroW3wjDd7XQLwAuYfwa4ZeTBCGFoYc',
  controller: 'did:key:z6LSnjagzhe8Df6gZmroW3wjDd7XQLwAuYfwa4ZeTBCGFoYc',
  publicKeyJwk: {
    kty: 'OKP',
    crv: 'X25519',
    x: 'pE_mG098rdQjY3MKK2D5SUQ6ZOEW3a6Z6T7Z4SgnzCE'
  }
}
```