### PR TITLE
Add five DID methods

### DIFF
--- a/index.html
+++ b/index.html
@@ -2848,6 +2848,91 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
             <a href="https://developer.iop.global/#/w3c">Morpheus DID Method</a>
           </td>
         </tr>
+        <tr>
+          <td>
+            did:etho:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Ethereum
+          </td>
+          <td>
+            Ontology Foundation
+          </td>
+          <td>
+            <a href="https://github.com/ontology-tech/DID-method-specs/blob/master/did-etho/DID-Method-etho.md">ETHO DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            did:bnb:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Binance Smart Chain
+          </td>
+          <td>
+            Ontology Foundation
+          </td>
+          <td>
+            <a href="https://github.com/ontology-tech/DID-method-specs/blob/master/did-bnb/DID-Method-bnb.md">Binance DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            did:celo:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Celo
+          </td>
+          <td>
+            Ontology Foundation
+          </td>
+          <td>
+            <a href="https://github.com/ontology-tech/DID-method-specs/blob/master/did-celo/DID-Method-celo.md">Celo DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            did:klay:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Klaytn
+          </td>
+          <td>
+            Ontology Foundation
+          </td>
+          <td>
+            <a href="https://github.com/ontology-tech/DID-method-specs/blob/master/did-klay/DID-Method-klay.md">Klaytn DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            did:trx:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            TRON
+          </td>
+          <td>
+            Ontology Foundation
+          </td>
+          <td>
+            <a href="https://github.com/ontology-tech/DID-method-specs/blob/master/did-trx/DID-Method-trx.md">TRON DID Method</a>
+          </td>
+        </tr>
       </tbody>
     </table>
 


### PR DESCRIPTION
Hello,

We want to add five DID methods for applications, namely,  `did:etho`, `did:bnb`, `did:celo`, `did:klay` and `did:trx`.

Spec for `did:etho` here: https://github.com/ontology-tech/DID-method-specs/blob/master/did-etho/DID-Method-etho.md
Spec for `did:bnb` here: https://github.com/ontology-tech/DID-method-specs/blob/master/did-bnb/DID-Method-bnb.md
Spec for `did:celo` here: https://github.com/ontology-tech/DID-method-specs/blob/master/did-celo/DID-Method-celo.md
Spec for `did:klay` here: https://github.com/ontology-tech/DID-method-specs/blob/master/did-klay/DID-Method-klay.md
Spec for `did:trx` here: https://github.com/ontology-tech/DID-method-specs/blob/master/did-trx/DID-Method-trx.md

Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ontology-tech/did-spec-registries/pull/106.html" title="Last updated on Aug 14, 2020, 9:59 AM UTC (5a069c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/106/bcd8c73...ontology-tech:5a069c6.html" title="Last updated on Aug 14, 2020, 9:59 AM UTC (5a069c6)">Diff</a>