### PR TITLE
Remove proof property from did document

### DIFF
--- a/contexts/did-v1.jsonld
+++ b/contexts/did-v1.jsonld
@@ -51,11 +51,6 @@
       "@type": "@id",
       "@container": "@set"
     },
-    "proof": {
-      "@id": "sec:proof",
-      "@type": "@id",
-      "@container": "@graph"
-    },
     "publicKey": {
       "@id": "sec:publicKey",
       "@type": "@id",

--- a/index.html
+++ b/index.html
@@ -468,39 +468,6 @@ DID Core. See <a href="https://github.com/w3c/did-core/issues/283">issue
 
       </section>
 
-      <section>
-        <h4><dfn data-lt="proof" data-dfn-type="dfn" id="proof">proof</dfn></h4>
-        <p class="issue">
-Subject to removal from DID Core - see
-<a href="https://github.com/w3c/did-core/issues/293">issue #293</a>.
-        </p>
-
-        <table class="simple" style="width: 100%;">
-          <thead>
-            <tr>
-              <th>Normative Definition</th>
-              <th>JSON-LD</th>
-              <th>CBOR</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <a href="https://w3c.github.io/did-core/#proof">DID Core</a>
-              </td>
-              <td>
-              </td>
-              <td>
-                <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
-              </td>
-              <td>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-      </section>
-
     </section>
 
     <section>


### PR DESCRIPTION
I believe we had consensus that proofs and signature suites belong in extensions. 

This PR removes proof from the did core context, and the did document properties.

If folks desire to re-register it as an extension (for Linked Data Proof signed did documents) that should be done in a seperate PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/116.html" title="Last updated on Aug 20, 2020, 1:48 PM UTC (9d4ab0e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/116/e7972c2...9d4ab0e.html" title="Last updated on Aug 20, 2020, 1:48 PM UTC (9d4ab0e)">Diff</a>