### PR TITLE
Add relative-ref DID URL parameter.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1539,6 +1539,28 @@ did:example:123?version-time=2016-10-17T02:41:00Z
     </section>
 
     <section>
+      <h4><dfn data-lt="relative-ref" data-dfn-type="dfn" id="relative-ref">relative-ref</dfn></h4>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="http://w3c.github.io/did-core/#generic-did-url-parameters">DID Core</a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <pre class="example" title="Example of relative-ref parameter">
+did:example:123?service=files&relative-ref=%2Fmyresume%2Fdoc%3Fversion%3Dlatest%23intro
+      </pre>
+    </section>
+
+    <section>
       <h4><dfn data-lt="initial-state" data-dfn-type="dfn" id="initial-state">initial-state</dfn></h4>
       <table class="simple" style="width: 100%;">
         <thead>


### PR DESCRIPTION
The `relative-ref` DID URL parameter was added to DID Core in https://github.com/w3c/did-core/pull/357.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-spec-registries/pull/118.html" title="Last updated on Aug 25, 2020, 11:10 PM UTC (6c8ca40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/118/9b371bd...peacekeeper:6c8ca40.html" title="Last updated on Aug 25, 2020, 11:10 PM UTC (6c8ca40)">Diff</a>