### PR TITLE
Update entries for metadata properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -1327,41 +1327,98 @@ for the value of <code>type</code> in a verification method object.
   </section>
 
     <section>
-      <h3>DID Resolution Request Metadata</h3>
+      <h3>DID Resolution Input Metadata</h3>
       <p>
         These properties contain information pertaining to the DID resolution request.
       </p>
 
       <section>
         <h4><dfn data-lt="accept" data-dfn-type="dfn" id="accept">accept</dfn></h4>
-        <p class="issue" data-number="108"></p>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://w3c.github.io/did-core/#did-resolution-input-metadata-properties">DID Core</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of accept metadata property">
+{
+  "accept": "application/did+ld+json"
+}
+        </pre>
       </section>
     </section>
   </section>
 
     <section>
-      <h3>DID Resolution Response Metadata</h3>
+      <h3>DID Resolution Metadata</h3>
       <p>
 These properties contain information pertaining to the DID resolution response.
       </p>
       <section>
         <h4><dfn data-lt="content-type" data-dfn-type="dfn" id="content-type">content-type</dfn></h4>
-        <p class="issue" data-number="109"></p>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://w3c.github.io/did-core/#did-resolution-metadata-properties">DID Core</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of content-type metadata property">
+{
+  "content-type": "application/did+ld+json"
+}
+        </pre>
       </section>
 
       <section>
         <h4><dfn data-lt="error" data-dfn-type="dfn" id="error">error</dfn></h4>
-        <p class="issue" data-number="110"></p>
-      </section>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://w3c.github.io/did-core/#did-resolution-metadata-properties">DID Core</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
-      <section>
-        <h4><dfn data-lt="invalid-did" data-dfn-type="dfn" id="invalid-did">invalid-did</dfn></h4>
-        <p class="issue" data-number="111"></p>
-      </section>
+        <pre class="example" title="Example of error metadata property">
+{
+  "error": "not-found"
+}
+        </pre>
 
-      <section>
-        <h4><dfn data-lt="unauthorized" data-dfn-type="dfn" id="unauthorized">unauthorized</dfn></h4>
-        <p class="issue" data-number="112"></p>
+        <section>
+          <h4><dfn data-lt="invalid-did" data-dfn-type="dfn" id="invalid-did">invalid-did</dfn></h4>
+          <p class="issue" data-number="111"></p>
+        </section>
+
+        <section>
+          <h4><dfn data-lt="unauthorized" data-dfn-type="dfn" id="unauthorized">unauthorized</dfn></h4>
+          <p class="issue" data-number="112"></p>
+        </section>
       </section>
     </section>
 


### PR DESCRIPTION
Adds links and examples for `accept`, `content-type` and `error` metadata properties.

Fixes https://github.com/w3c/did-spec-registries/issues/108. Fixes https://github.com/w3c/did-spec-registries/issues/109. Fixes https://github.com/w3c/did-spec-registries/issues/110.

Renames "DID Resolution Request Metadata" to "DID Resolution Input Metadata", and "DID Resolution Response Metadata" to "DID Resolution Metadata", to be consistent with DID Core.

Also makes error codes a subsection of the "error" metadata property.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-spec-registries/pull/120.html" title="Last updated on Aug 26, 2020, 4:21 PM UTC (d9a2584)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/120/9b371bd...peacekeeper:d9a2584.html" title="Last updated on Aug 26, 2020, 4:21 PM UTC (d9a2584)">Diff</a>