### PR TITLE
Add the Blockcore DID Method to registry list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1873,6 +1873,23 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
         </tr>
         <tr>
           <td>
+              did:is:
+          </td>
+          <td>
+              PROVISIONAL
+          </td>
+          <td>
+              Blockcore
+          </td>
+          <td>
+              Blockcore
+          </td>
+          <td>
+            <a href="https://github.com/block-core/blockcore-did-method">Blockcore DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
               did:iwt:
           </td>
           <td>


### PR DESCRIPTION
- Adds the Blockcore DID Method specification to the registry list.
- Specification is currently in an initial draft, with a currently working identity framework with intention to develop a .NET based driver for Universal Resolver.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sondreb/did-spec-registries/pull/122.html" title="Last updated on Aug 30, 2020, 11:43 PM UTC (047e7b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/122/d618fa8...sondreb:047e7b3.html" title="Last updated on Aug 30, 2020, 11:43 PM UTC (047e7b3)">Diff</a>