### PR TITLE
 add a new DID method did:schema to main index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2797,6 +2797,23 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
             <a href="https://github.com/ontology-tech/DID-method-specs/blob/master/did-trx/DID-Method-trx.md">TRON DID Method</a>
           </td>
         </tr>
+        <tr>
+          <td>
+              did:schema:
+          </td>
+          <td>
+              PROVISIONAL
+          </td>
+          <td>
+              Multiple storage networks, currently public IPFS and evan.network IPFS
+          </td>
+          <td>
+              51nodes GmbH
+          </td>
+          <td>
+              <a href="https://github.com/51nodes/schema-registry-did-method/blob/master/README.md">Schema Registry DID Method</a>
+          </td>
+      </tr>
       </tbody>
     </table>
 


### PR DESCRIPTION
Hi, sorry for the additional effort that will be caused.. in my last Pull request (add Schema did method) I added the code to the wrong index.html file under FPWD/2020-06-18/.. instead of adding it to the main index.html.
nothing at the did method has been changed.. so could you please merg this pull request as well. Thanks
`       <tr>
          <td>
              did:schema:
          </td>
          <td>
              PROVISIONAL
          </td>
          <td>
              Multiple storage networks, currently public IPFS and evan.network IPFS
          </td>
          <td>
              51nodes GmbH
          </td>
          <td>
              <a href="https://github.com/51nodes/schema-registry-did-method/blob/master/README.md">Schema Registry DID Method</a>
          </td>
      </tr>`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/51nodes/did-spec-registries/pull/123.html" title="Last updated on Aug 31, 2020, 7:07 AM UTC (b22c49b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/123/d618fa8...51nodes:b22c49b.html" title="Last updated on Aug 31, 2020, 7:07 AM UTC (b22c49b)">Diff</a>