### PR TITLE
Tidy up section headings and ids

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,7 +242,7 @@ be possible to submit items to the registry without normative definitions (see <
 These properties are foundational to DID documents, and are expected to be
 useful to all DID methods.
       <section>
-        <h4><dfn data-lt="@context" data-dfn-type="dfn" id="@context">@context</dfn></h4>
+        <h4>@context</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -279,7 +279,7 @@ useful to all DID methods.
       </section>
 
       <section>
-        <h4><dfn data-lt="id" data-dfn-type="dfn" id="id">id</dfn></h4>
+        <h4>id</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -312,7 +312,7 @@ useful to all DID methods.
       </section>
 
       <section>
-        <h4><dfn data-lt="controller" data-dfn-type="dfn" id="controller">controller</dfn></h4>
+        <h4>controller</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -346,7 +346,7 @@ useful to all DID methods.
 
 
       <section>
-        <h4><dfn data-lt="verificationMethod" data-dfn-type="dfn" id="verificationMethod">verificationMethod</dfn></h4>
+        <h4>verificationMethod</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -374,7 +374,7 @@ useful to all DID methods.
       </section>
 
       <section>
-        <h4><dfn data-lt="publicKey" data-dfn-type="dfn" id="publicKey">publicKey</dfn></h4>
+        <h4>publicKey</h4>
 
         <p class="issue">
 This property may be replaced entirely by <code>verificationMethod</code> in
@@ -432,7 +432,7 @@ DID Core. See <a href="https://github.com/w3c/did-core/issues/283">issue
       </section>
 
       <section>
-        <h4><dfn data-lt="service" data-dfn-type="dfn" id="service">service</dfn></h4>
+        <h4>service</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -474,10 +474,10 @@ DID Core. See <a href="https://github.com/w3c/did-core/issues/283">issue
       <h3>Services</h3>
       <p>
 These terms are properties or types belonging to objects in the value of
-<a>service</a>.
+<a href="#service"></a>.
       </p>
       <section>
-        <h4><dfn data-lt="serviceEndpoint" data-dfn-type="dfn" id="serviceEndpoint">serviceEndpoint</dfn></h4>
+        <h4>serviceEndpoint</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -523,7 +523,7 @@ verification method using a
 verification relationship</a>.
       </p>
       <section>
-        <h4><dfn data-lt="assertionMethod" data-dfn-type="dfn" id="assertionMethod">assertionMethod</dfn></h4>
+        <h4>assertionMethod</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -575,7 +575,7 @@ verification relationship</a>.
       </section>
 
       <section>
-        <h4><dfn data-lt="authentication" data-dfn-type="dfn" id="authentication">authentication</dfn></h4>
+        <h4>authentication</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -627,7 +627,7 @@ verification relationship</a>.
       </section>
 
       <section>
-        <h4><dfn data-lt="capabilityDelegation" data-dfn-type="dfn" id="capabilityDelegation">capabilityDelegation</dfn></h4>
+        <h4>capabilityDelegation</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -678,7 +678,7 @@ verification relationship</a>.
       </section>
 
       <section>
-        <h4><dfn data-lt="capabilityInvocation" data-dfn-type="dfn" id="capabilityInvocation">capabilityInvocation</dfn></h4>
+        <h4>capabilityInvocation</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -729,7 +729,7 @@ verification relationship</a>.
       </section>
 
       <section>
-        <h4><dfn data-lt="keyAgreement" data-dfn-type="dfn" id="keyAgreement">keyAgreement</dfn></h4>
+        <h4>keyAgreement</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -775,7 +775,7 @@ verification relationship</a>.
 These properties are for use on a verification method object, not on the DID document itself.
       </p>
       <section>
-        <h4><dfn data-lt="ethereumAddress" data-dfn-type="dfn" id="ethereumAddress">ethereumAddress</dfn></h4>
+        <h4>ethereumAddress</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -817,7 +817,7 @@ These properties are for use on a verification method object, not on the DID doc
       </section>
 
       <section>
-        <h4><dfn data-lt="publicKeyHex" data-dfn-type="dfn" id="publicKeyHex">publicKeyHex</dfn></h4>
+        <h4>publicKeyHex</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -859,7 +859,7 @@ These properties are for use on a verification method object, not on the DID doc
       </section>
 
       <section>
-        <h4><dfn data-lt="publicKeyJwk" data-dfn-type="dfn" id="publicKeyJwk">publicKeyJwk</dfn></h4>
+        <h4>publicKeyJwk</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -901,7 +901,7 @@ These properties are for use on a verification method object, not on the DID doc
       </section>
 
       <section>
-        <h4><dfn data-lt="publicKeyBase58" data-dfn-type="dfn" id="publicKeyBase58">publicKeyBase58</dfn></h4>
+        <h4>publicKeyBase58</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -930,7 +930,7 @@ These properties are for use on a verification method object, not on the DID doc
       </section>
 
       <section>
-        <h4><dfn data-lt="publicKeyPem" data-dfn-type="dfn" id="publicKeyPem">publicKeyPem</dfn></h4>
+        <h4>publicKeyPem</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -966,7 +966,7 @@ These are <em>classes</em> not a <em>properties</em> - in other words, use them
 for the value of <code>type</code> in a verification method object.
       </p>
       <section>
-        <h4><dfn data-lt="JsonWebKey2020" data-dfn-type="dfn" id="JsonWebKey2020">JsonWebKey2020</dfn></h4>
+        <h4>JsonWebKey2020</h4>
 
         <p class="issue">
 <a href="https://github.com/w3c/did-core/issues/240">ISSUE 240 on DID Core</a>: The duplication and/or possible interaction of properties held in a JWK and a verification method are an active topic of discussion in the Working Group. Implementers are cautioned that the behavior of values associated with this property are not stable and might change in the future.
@@ -1010,7 +1010,7 @@ for the value of <code>type</code> in a verification method object.
         </pre>
       </section>
       <section>
-        <h4><dfn data-lt="EcdsaSecp256k1VerificationKey2019" data-dfn-type="dfn" id="EcdsaSecp256k1VerificationKey2019">EcdsaSecp256k1VerificationKey2019</dfn></h4>
+        <h4>EcdsaSecp256k1VerificationKey2019</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -1051,7 +1051,7 @@ for the value of <code>type</code> in a verification method object.
       </section>
 
       <section>
-        <h4><dfn data-lt="Ed25519VerificationKey2018" data-dfn-type="dfn" id="Ed25519VerificationKey2018">Ed25519VerificationKey2018</dfn></h4>
+        <h4>Ed25519VerificationKey2018</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -1086,7 +1086,7 @@ for the value of <code>type</code> in a verification method object.
       </section>
 
       <section>
-        <h4><dfn data-lt="GpgVerificationKey2020" data-dfn-type="dfn" id="GpgVerificationKey2020">GpgVerificationKey2020</dfn></h4>
+        <h4>GpgVerificationKey2020</h4>
         <p class="warning">
           No support for "Pure JSON" or "CBOR" is currently provided.
         </p>
@@ -1131,7 +1131,7 @@ for the value of <code>type</code> in a verification method object.
       </section>
 
       <section>
-        <h4><dfn data-lt="RsaVerificationKey2018" data-dfn-type="dfn" id="RsaVerificationKey2018">RsaVerificationKey2018</dfn></h4>
+        <h4>RsaVerificationKey2018</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -1167,7 +1167,7 @@ for the value of <code>type</code> in a verification method object.
       </section>
 
       <section>
-        <h4><dfn data-lt="X25519KeyAgreementKey2019" data-dfn-type="dfn" id="X25519KeyAgreementKey2019">X25519KeyAgreementKey2019</dfn></h4>
+        <h4>X25519KeyAgreementKey2019</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -1206,7 +1206,7 @@ for the value of <code>type</code> in a verification method object.
       </section>
 
       <section>
-        <h4><dfn data-lt="SchnorrSecp256k1VerificationKey2019" data-dfn-type="dfn" id="SchnorrSecp256k1VerificationKey2019">SchnorrSecp256k1VerificationKey2019</dfn></h4>
+        <h4>SchnorrSecp256k1VerificationKey2019</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -1232,7 +1232,7 @@ for the value of <code>type</code> in a verification method object.
       </section>
 
       <section>
-        <h4><dfn data-lt="EcdsaSecp256k1RecoveryMethod2020" data-dfn-type="dfn" id="EcdsaSecp256k1RecoveryMethod2020">EcdsaSecp256k1RecoveryMethod2020</dfn></h4>
+        <h4>EcdsaSecp256k1RecoveryMethod2020</h4>
 
         <table class="simple" style="width: 100%;">
           <thead>
@@ -1300,7 +1300,7 @@ for the value of <code>type</code> in a verification method object.
       </p>
 
       <section>
-        <h4><dfn data-lt="accept" data-dfn-type="dfn" id="accept">accept</dfn></h4>
+        <h4>accept</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1331,7 +1331,7 @@ for the value of <code>type</code> in a verification method object.
 These properties contain information pertaining to the DID resolution response.
       </p>
       <section>
-        <h4><dfn data-lt="content-type" data-dfn-type="dfn" id="content-type">content-type</dfn></h4>
+        <h4>content-type</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1355,7 +1355,7 @@ These properties contain information pertaining to the DID resolution response.
       </section>
 
       <section>
-        <h4><dfn data-lt="error" data-dfn-type="dfn" id="error">error</dfn></h4>
+        <h4>error</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1378,14 +1378,15 @@ These properties contain information pertaining to the DID resolution response.
         </pre>
 
         <section>
-          <h4><dfn data-lt="invalid-did" data-dfn-type="dfn" id="invalid-did">invalid-did</dfn></h4>
+          <h4>invalid-did</h4>
           <p class="issue" data-number="111"></p>
         </section>
 
         <section>
-          <h4><dfn data-lt="unauthorized" data-dfn-type="dfn" id="unauthorized">unauthorized</dfn></h4>
+          <h4>unauthorized</h4>
           <p class="issue" data-number="112"></p>
         </section>
+
       </section>
     </section>
 
@@ -1396,7 +1397,7 @@ These properties contain information pertaining to the DID document itself,
 rather than the DID subject.
       </p>
       <section>
-        <h4><dfn data-lt="created" data-dfn-type="dfn" id="created">created</dfn></h4>
+        <h4>created</h4>
         <p class="issue" >
           See <a href="https://github.com/w3c/did-core/issues/203">DID Core #203</a>.
         </p>
@@ -1431,7 +1432,7 @@ rather than the DID subject.
       </section>
 
       <section>
-        <h4><dfn data-lt="updated" data-dfn-type="dfn" id="updated">updated</dfn></h4>
+        <h4>updated</h4>
         <p class="issue" >
           See <a href="https://github.com/w3c/did-core/issues/203">DID Core #203</a>.
         </p>
@@ -1475,7 +1476,7 @@ rather than the DID subject.
     <h1>Parameters</h1>
 
     <section>
-      <h4><dfn data-lt="hl" data-dfn-type="dfn" id="hl">hl</dfn></h4>
+      <h4 id="hl-param">hl</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -1497,7 +1498,7 @@ did:example:123?hl=zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e
     </section>
 
     <section>
-      <h4><dfn data-lt="service" data-dfn-type="dfn" id="service">service</dfn></h4>
+      <h4 id="service-param">service</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -1519,7 +1520,7 @@ did:example:123?service=agent
     </section>
 
     <section>
-      <h4><dfn data-lt="version-id" data-dfn-type="dfn" id="version-id">version-id</dfn></h4>
+      <h4 id="version-id-param">version-id</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -1541,7 +1542,7 @@ did:example:123?version-id=4
     </section>
 
     <section>
-      <h4><dfn data-lt="version-time" data-dfn-type="dfn" id="version-time">version-time</dfn></h4>
+      <h4 id="version-time-param">version-time</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -1563,7 +1564,7 @@ did:example:123?version-time=2016-10-17T02:41:00Z
     </section>
 
     <section>
-      <h4><dfn data-lt="relative-ref" data-dfn-type="dfn" id="relative-ref">relative-ref</dfn></h4>
+      <h4 id="relative-ref-param">relative-ref</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -1585,7 +1586,7 @@ did:example:123?service=files&relative-ref=%2Fmyresume%2Fdoc%3Fversion%3Dlatest%
     </section>
 
     <section>
-      <h4><dfn data-lt="initial-state" data-dfn-type="dfn" id="initial-state">initial-state</dfn></h4>
+      <h4 id="initial-state-param">initial-state</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -1607,7 +1608,7 @@ did:example:123?initial-state=eyJkZWx0YV9oYXNoIjoiRWlDUlRKZ2Q0U0V2YUZDLW9fNUZjQn
     </section>
 
     <section>
-      <h4><dfn data-lt="transform-keys" data-dfn-type="dfn" id="transform-keys">transform-keys</dfn></h4>
+      <h4 id="transform-keys-param">transform-keys</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>


### PR DESCRIPTION
Removes the dfn elements which were causing duplicate ids, and adds `-param` to the end of all the parameter section heading ids so they will never clash with the same terms from properties.

Fixes #113


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/124.html" title="Last updated on Sep 21, 2020, 1:44 PM UTC (797fe36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/124/da838bb...797fe36.html" title="Last updated on Sep 21, 2020, 1:44 PM UTC (797fe36)">Diff</a>