### PR TITLE
Added `alsoKnownAs` to the context

### DIFF
--- a/contexts/did-v1.jsonld
+++ b/contexts/did-v1.jsonld
@@ -18,7 +18,7 @@
     "X25519KeyAgreementKey2019": "sec:X25519KeyAgreementKey2019",
     "ServiceEndpointProxyService": "didv:ServiceEndpointProxyService",
     "alsoKnownAs": {
-      "@id": "sec:alsoKnownAs",
+      "@id": "https://www.w3.org/ns/activitystreams#alsoKnownAs",
       "@type": "@id",
       "@container": "@set"
     },

--- a/contexts/did-v1.jsonld
+++ b/contexts/did-v1.jsonld
@@ -17,6 +17,11 @@
     "SchnorrSecp256k1VerificationKey2019": "sec:SchnorrSecp256k1VerificationKey2019",
     "X25519KeyAgreementKey2019": "sec:X25519KeyAgreementKey2019",
     "ServiceEndpointProxyService": "didv:ServiceEndpointProxyService",
+    "alsoKnownAs": {
+      "@id": "sec:alsoKnownAs",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "assertionMethod": {
       "@id": "sec:assertionMethod",
       "@type": "@id",


### PR DESCRIPTION
Note that, although I used the `sec:` vocabulary, the property itself is _not_ present in that [vocabulary document](https://w3c-ccg.github.io/security-vocab/). This must be done separately.