### PR TITLE
Fix links to created and updated in DID Core

### DIFF
--- a/index.html
+++ b/index.html
@@ -1409,7 +1409,7 @@ rather than the DID subject.
           <tbody>
             <tr>
               <td>
-                <a href="https://www.w3.org/TR/did-core/#created">DID Core</a>
+                <a href="https://www.w3.org/TR/did-core/#did-document-metadata-properties">DID Core</a>
               </td>
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
@@ -1444,7 +1444,7 @@ rather than the DID subject.
           <tbody>
             <tr>
               <td>
-                <a href="https://www.w3.org/TR/did-core/#updated">DID Core</a>
+                <a href="https://www.w3.org/TR/did-core/#did-document-metadata-properties">DID Core</a>
               </td>
 
               <td>


### PR DESCRIPTION
`created` and `updated` were moved to the DID document metadata properties subsection in DID Core, so I've updated these links.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/135.html" title="Last updated on Sep 21, 2020, 7:25 PM UTC (c4744a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/135/0472aa5...c4744a1.html" title="Last updated on Sep 21, 2020, 7:25 PM UTC (c4744a1)">Diff</a>