### PR TITLE
Remove @context as Core Property

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,43 +239,6 @@ be possible to submit items to the registry without normative definitions (see <
 These properties are foundational to DID documents, and are expected to be
 useful to all DID methods.
       <section>
-        <h4>@context</h4>
-
-        <table class="simple" style="width: 100%;">
-          <thead>
-            <tr>
-              <th>Normative Definition</th>
-              <th>JSON-LD</th>
-              <th>CBOR</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <a href="https://www.w3.org/TR/did-core/#production-0">DID Core</a>
-              </td>
-              <td>
-                <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
-              </td>
-              <td>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <pre class="example" title="Example of @context property">
-{
-  "@context": [
-    "https://www.w3.org/ns/did/v1",
-    "https://example.com/blockchain-identity/v1"
-  ],
-  ...
-}
-        </pre>
-
-      </section>
-
-      <section>
         <h4>id</h4>
 
         <table class="simple" style="width: 100%;">


### PR DESCRIPTION
Fixes https://github.com/w3c/did-spec-registries/issues/131.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/139.html" title="Last updated on Sep 29, 2020, 11:03 AM UTC (d0d2890)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/139/6859f91...d0d2890.html" title="Last updated on Sep 29, 2020, 11:03 AM UTC (d0d2890)">Diff</a>