### PR TITLE
Require hash of JSON-LD context

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@ The JSON-LD Context MUST be included in full as part of the submission.
           </li>
           <li>
 A cryptographic hash of the JSON-LD Context SHOULD be included as part of the
-submission.
+submission, and computed according to <a href="#json-ld-context-integrity"></a>.
           </li>
           <li>
 A namespace URI MUST be provided for the JSON-LD Context so that consumer
@@ -225,6 +225,26 @@ Any submission to the registries that meet all the criteria listed above will be
 accepted for inclusion. These registries enumerate all known mechanisms that
 meet a minimum bar, without choosing between them.
     </p>
+
+    <section>
+      <h2>
+JSON-LD context integrity
+      </h2>
+      <p>
+When included, the cryptographic hash of the content of the JSON-LD Context MUST be
+computed in a manner equivalent to the following:
+            </p>
+            <pre class="example">
+curl -s https://www.w3.org/ns/did/v1 | openssl sha256
+            </pre>
+            <p>
+The command above will result in the following hash, expressed in hexadecimal notation:
+            </p>
+            <pre class="example">
+910cd6648f6f7b72a7896a8da83e63460eb8355a0af4b56b699c9281452ac8bb
+            </pre>
+            </p>
+    </section>
   </section>
 
 

--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@ specify a machine readable JSON-LD Context for the addition.
 The JSON-LD Context MUST be included in full as part of the submission.
           </li>
           <li>
-A cryptographic hash of the JSON-LD Context MUST be included as part of the
+A cryptographic hash of the JSON-LD Context SHOULD be included as part of the
 submission.
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -177,6 +177,10 @@ specify a machine readable JSON-LD Context for the addition.
 The JSON-LD Context MUST be included in full as part of the submission.
           </li>
           <li>
+A cryptographic hash of the JSON-LD Context MUST be included as part of the
+submission.
+          </li>
+          <li>
 A namespace URI MUST be provided for the JSON-LD Context so that consumer
 implementations can consistently map a URI to the full context.
           </li>


### PR DESCRIPTION
For a while there has been language in the DID Core spec about the JSON-LD context in the Registries being associated with a hash. Currently it's [in JSON-LD consumption](https://w3c.github.io/did-core/#consumption-0) but in https://github.com/w3c/did-core/pull/436 its moved to production:

> URLs registered in the DID Specification Registries [DID-SPEC-REGISTRIES] referring to JSON-LD Contexts SHOULD be associated with a cryptographic hash of the content of the JSON-LD Context.

In https://github.com/w3c/did-core/issues/403 Ivan points out that the DID Core spec can't make this requirement of the Registries. So I have added it as a requirement of the registration process in this PR. The DID Core spec can then add language about checking against the hash in JSON-LD consumption if necessary.

I think this then means the Registries needs to display the hash somewhere? It's gonna get messy for every one but maybe we can find some nice css/js to collapse them or something.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/146.html" title="Last updated on Jan 10, 2021, 3:44 PM UTC (d8f42c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/146/b07450b...d8f42c8.html" title="Last updated on Jan 10, 2021, 3:44 PM UTC (d8f42c8)">Diff</a>