### PR TITLE
methods: Add link to normative requirements of DID method specs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1631,10 +1631,15 @@ did:example:123?transform-keys=jwk
   <section>
     <h1>DID Methods</h1>
 
-
     <p>
 This table summarizes the DID method specifications currently in development.
 The links will be updated as subsequent Implementer’s Drafts are produced.
+    </p>
+    <p>
+The normative requirements for DID method specifications can be found in
+<a href="https://www.w3.org/TR/did-core/#methods">Decentralized Identifiers
+v1.0: Methods</a> [[DID-CORE]]. DID methods that do not meet these requirements
+will not be accepted.
     </p>
 
     <table class="simple">


### PR DESCRIPTION
In https://github.com/w3c/did-core/issues/403 Ivan notes that it would be useful for the DID methods section in the registry to link back to the normative requirements for methods specs. I also added the line that only conforming methods are accepted to the Registries, which I'm 99% sure is accurate. Did we lose a complete registration process for methods somewhere which needs adding back?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/147.html" title="Last updated on Oct 25, 2020, 12:11 PM UTC (eb63f30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/147/615a06d...eb63f30.html" title="Last updated on Oct 25, 2020, 12:11 PM UTC (eb63f30)">Diff</a>