### PR TITLE
Update list of error values.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1376,12 +1376,98 @@ These properties contain information pertaining to the DID resolution response.
 
         <section>
           <h4>invalid-did</h4>
-          <p class="issue" data-number="111"></p>
+          <table class="simple" style="width: 100%;">
+            <thead>
+              <tr>
+                <th>Normative Definition</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <a href="https://w3c.github.io/did-core/#did-resolution-metadata-properties">DID Core</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <pre class="example" title="Example of invalid-did error value">
+{
+  "error": "invalid-did"
+}
+          </pre>
         </section>
 
         <section>
-          <h4>unauthorized</h4>
-          <p class="issue" data-number="112"></p>
+          <h4>invalid-did-url</h4>
+          <table class="simple" style="width: 100%;">
+            <thead>
+              <tr>
+                <th>Normative Definition</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <a href="https://w3c.github.io/did-core/#did-url-dereferencing-metadata-properties">DID Core</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <pre class="example" title="Example of invalid-did-url error value">
+{
+  "error": "invalid-did-url"
+}
+          </pre>
+        </section>
+
+        <section>
+          <h4>not-found</h4>
+          <table class="simple" style="width: 100%;">
+            <thead>
+              <tr>
+                <th>Normative Definition</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <a href="https://w3c.github.io/did-core/#did-resolution-metadata-properties">DID Core</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <pre class="example" title="Example of not-found error value">
+{
+  "error": "not-found"
+}
+          </pre>
+        </section>
+
+        <section>
+          <h4>deactivated</h4>
+          <table class="simple" style="width: 100%;">
+            <thead>
+              <tr>
+                <th>Normative Definition</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <a href="https://w3c.github.io/did-core/#did-resolution-metadata-properties">DID Core</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <pre class="example" title="Example of deactivated error value">
+{
+  "error": "deactivated"
+}
+          </pre>
         </section>
 
       </section>


### PR DESCRIPTION
Add `invalid-did`, `invalid-did-url`, `not-found`, `deactivated` error values.

Remove `unauthorized` error value (removed from DID Core, see https://github.com/w3c/did-spec-registries/issues/112).

Fixes https://github.com/w3c/did-spec-registries/issues/111.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-spec-registries/pull/151.html" title="Last updated on Nov 5, 2020, 12:39 PM UTC (5ae96d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/151/91b505a...peacekeeper:5ae96d9.html" title="Last updated on Nov 5, 2020, 12:39 PM UTC (5ae96d9)">Diff</a>