### PR TITLE
Add @BlockchainCommons/did-method-onion

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,8 +200,8 @@ feature to eliminate the possibility of term conflicts.
 Properties in the DID Core Registries MUST NOT be removed, only deprecated.
       </li>
       <li>
-Properties definitions in the DID Core Registries MUST include a Concise Data Definition Language (CDDL) [[RFC8610]] of the 
-Property and it's Abstract Data model structure. 
+Properties definitions in the DID Core Registries MUST include a Concise Data Definition Language (CDDL) [[RFC8610]] of the
+Property and it's Abstract Data model structure.
       </li>
     </ol>
 
@@ -243,11 +243,11 @@ be possible to submit items to the registry without normative definitions (see <
     </p>
 
 <p>
-  Concise Data Defition Lanuage (CDDL) provides a succint data defition for representing JSON and CBOR core representations of  
-  a DID document as described in the <a href="https://www.w3.org/TR/did-core/#core-representations" taret="_blank">DID Core Specification</a> and associated properties registered in this <a href="https://w3c.github.io/did-spec-registries/" target="_blank">DID Spec Registeries</a>.  
-  The draft composite CDDL definition for the entire DID Document Specifation and associated 
-  registeries can be found <a href="cddl/did-document.cddl" target="_blank">here</a>.  
-  Additionally, each Property, Class and Type are described separately below and can be found below the `CDDL` column and apply to JSON and CBOR representations only.     
+  Concise Data Defition Lanuage (CDDL) provides a succint data defition for representing JSON and CBOR core representations of
+  a DID document as described in the <a href="https://www.w3.org/TR/did-core/#core-representations" taret="_blank">DID Core Specification</a> and associated properties registered in this <a href="https://w3c.github.io/did-spec-registries/" target="_blank">DID Spec Registeries</a>.
+  The draft composite CDDL definition for the entire DID Document Specifation and associated
+  registeries can be found <a href="cddl/did-document.cddl" target="_blank">here</a>.
+  Additionally, each Property, Class and Type are described separately below and can be found below the `CDDL` column and apply to JSON and CBOR representations only.
 </p>
 
     <section>
@@ -281,7 +281,7 @@ useful to all DID methods.
         </table>
 
         <p class="issue">
-          This is an active area of debate regarding if <code>@context</code> belongs as a base property in the 
+          This is an active area of debate regarding if <code>@context</code> belongs as a base property in the
           DID Core. See <a href="https://github.com/w3c/did-core/issues/432">issue
           #283</a>.
                   </p>
@@ -1027,7 +1027,7 @@ for the value of <code>type</code> in a verification method object.
               <td>
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
               </td>
-              <td>                
+              <td>
                 <a href="cddl/verificationMethodTypes.cddl" target="_blank">verificationMethodTypes.cddl</a>
               </td>
             </tr>
@@ -1070,7 +1070,7 @@ for the value of <code>type</code> in a verification method object.
                 <a href="https://www.w3.org/ns/did/v1">DID Core context</a>
               </td>
               <td>
-                <a href="cddl/verificationMethodTypes.cddl" target="_blank">verificationMethodTypes.cddl</a> 
+                <a href="cddl/verificationMethodTypes.cddl" target="_blank">verificationMethodTypes.cddl</a>
               </td>
             </tr>
           </tbody>
@@ -1088,7 +1088,7 @@ for the value of <code>type</code> in a verification method object.
 
       <section>
         <h4>GpgVerificationKey2020</h4>
-      
+
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1777,7 +1777,7 @@ did:example:123?signed-ietf-json-patch=eyJraWQiOiJkaWQ6ZXhhbXBsZTo0NTYjX1FxMFVMM
 
     <p>
 This table summarizes the DID method specifications currently in development.
-The links will be updated as subsequent Implementer’s Drafts are produced. 
+The links will be updated as subsequent Implementer’s Drafts are produced.
     </p>
     <p>
 The normative requirements for DID method specifications can be found in
@@ -3163,6 +3163,23 @@ will not be accepted.
           </td>
           <td>
             <a href="https://github.com/medibloc/panacea-core/blob/master/docs/did.md">Panacea DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            did:onion:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Web
+          </td>
+          <td>
+            Christopher Allen, Orie Steele
+          </td>
+          <td>
+            <a href="https://blockchaincommons.github.io/did-method-onion/">DID Onion Method</a>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
This is a request to add did-method-onion for `did:onion` to the DID Spec Registry.

Note: there are some white space only changes in this PR, I'm not sure where they creeped in.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BlockchainCommons/did-spec-registries/pull/163.html" title="Last updated on Dec 11, 2020, 1:58 AM UTC (0b5b1db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/163/53453a3...BlockchainCommons:0b5b1db.html" title="Last updated on Dec 11, 2020, 1:58 AM UTC (0b5b1db)">Diff</a>