### PR TITLE
fix did namespace in contexts

### DIFF
--- a/contexts/README.md
+++ b/contexts/README.md
@@ -45,7 +45,7 @@ contexts (without necessarily cryptographically binding assurance).
 
 The current system for DID context versioning is:
 
-1. Use `https://www.w3.org/2019/did/v1` as an alias to the latest version of the
+1. Use `https://www.w3.org/ns/did/v1` as an alias to the latest version of the
   spec. Once the DID Working Group work concludes, the final v1 version will be
   frozen and made immutable.
 2. Use intermediate pre-v1 versioned URLs such as `https://w3id.org/did/v0.11`

--- a/contexts/did-v1.jsonld
+++ b/contexts/did-v1.jsonld
@@ -6,7 +6,7 @@
     "dc": "http://purl.org/dc/terms/",
     "schema": "http://schema.org/",
     "sec": "https://w3id.org/security#",
-    "didv": "https://w3id.org/did#",
+    "didns": "https://www.w3.org/ns/did/v1#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "EcdsaSecp256k1VerificationKey2019": "sec:EcdsaSecp256k1VerificationKey2019",
     "Ed25519Signature2018": "sec:Ed25519Signature2018",
@@ -68,12 +68,12 @@
       "@type": "@json"
     },
     "service": {
-      "@id": "didv:service",
+      "@id": "didns:service",
       "@type": "@id",
       "@container": "@set"
     },
     "serviceEndpoint": {
-      "@id": "didv:serviceEndpoint",
+      "@id": "didns:serviceEndpoint",
       "@type": "@id"
     },
     "updated": {


### PR DESCRIPTION
Updates the `w3id.org/did#` namespace to `w3.org/ns/did/v1#` (and changes the `didv` prefix to `didns`)

For #48