### PR TITLE
contexts: Remove terms not in DID Core Spec

### DIFF
--- a/contexts/did-v1.jsonld
+++ b/contexts/did-v1.jsonld
@@ -50,14 +50,8 @@
       "@id": "dc:created",
       "@type": "xsd:dateTime"
     },
-    "blockchainAccountId": "sec:blockchainAccountId",
     "keyAgreement": {
       "@id": "sec:keyAgreementMethod",
-      "@type": "@id",
-      "@container": "@set"
-    },
-    "publicKey": {
-      "@id": "sec:publicKey",
       "@type": "@id",
       "@container": "@set"
     },


### PR DESCRIPTION
My understanding is the only terms that should be in the DID Core context are terms which are normatively defined in the DID Core Specification.

I've removed `publicKey` as it was deprecated, and `blockchainAccountId` because I haven't seen any intention of that going in DID Core (and it's currently defined in the security vocab, as linked in #166).

I left `publicKeyJwk` and `publicKeyBase58` as I believe the intention _is_ to get these defined in DID Core imminently.