### PR TITLE
markup: Fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@ be possible to submit items to the registry without normative definitions (see <
 
 <p>
   Concise Data Defition Lanuage (CDDL) provides a succint data defition for representing JSON and CBOR core representations of  
-  a DID document as described in the <a href="https://www.w3.org/TR/did-core/#core-representations" taret="_blank">DID Core Specification</a> and associated properties registered in this <a href="https://w3c.github.io/did-spec-registries/" target="_blank">DID Spec Registeries</a>.  
+  a DID document as described in the <a href="https://www.w3.org/TR/did-core/#core-representations" target="_blank">DID Core Specification</a> and associated properties registered in this <a href="https://w3c.github.io/did-spec-registries/" target="_blank">DID Spec Registeries</a>.  
   The draft composite CDDL definition for the entire DID Document Specifation and associated 
   registeries can be found <a href="cddl/did-document.cddl" target="_blank">here</a>.  
   Additionally, each Property, Class and Type are described separately below and can be found below the `CDDL` column and apply to JSON and CBOR representations only.     


### PR DESCRIPTION
This broke the last echidna build!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: connect ETIMEDOUT 128.30.52.89:443 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Dec 14, 2020, 1:18 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fdid-spec-registries%2Fa523897a0f02ae0aee6ff3a5bf0d311847ecc5b0%2Findex.html%3FisPreview%3Dtrue)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/did-spec-registries%23171.)._
</details>
