### PR TITLE
Add email address for DID method spec author

### DIFF
--- a/index.html
+++ b/index.html
@@ -1868,7 +1868,7 @@ will not be accepted.
               Ethereum
           </td>
           <td>
-              Markus Sabadello, Fabian Vogelsteller, Peter Kolarov
+            <a href="mailto:markus@danubetech.com">Markus Sabadello</a>, Fabian Vogelsteller, Peter Kolarov
           </td>
           <td>
             <a href="https://github.com/WebOfTrustInfo/rebooting-the-web-of-trust-spring2018/blob/master/topics-and-advance-readings/DID-Method-erc725.md">erc725 DID Method</a>

--- a/index.html
+++ b/index.html
@@ -1868,7 +1868,7 @@ will not be accepted.
               Ethereum
           </td>
           <td>
-            <a href="mailto:markus@danubetech.com">Markus Sabadello</a>, Fabian Vogelsteller, Peter Kolarov
+            <a href="mailto:markus@danubetech.com">Markus Sabadello</a>, <a href="mailto:fabian@lukso.network">Fabian Vogelsteller</a>, Peter Kolarov
           </td>
           <td>
             <a href="https://github.com/WebOfTrustInfo/rebooting-the-web-of-trust-spring2018/blob/master/topics-and-advance-readings/DID-Method-erc725.md">erc725 DID Method</a>


### PR DESCRIPTION
It would be good if DID method spec authors included contact information, see https://github.com/w3c/did-spec-registries/issues/174.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/176.html" title="Last updated on Dec 22, 2020, 11:08 AM UTC (3796967)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/176/eb763ec...3796967.html" title="Last updated on Dec 22, 2020, 11:08 AM UTC (3796967)">Diff</a>