### PR TITLE
Add UNISOT DID method.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3339,6 +3339,23 @@ address in the Author Links column, as this helps with maintenance.
             <a href="https://github.com/identify202020/did-method/blob/main/did_kr_method.md">Korea Mobile Identity System DID Method</a>
           </td>
         </tr>
+        <tr>
+          <td>
+            did:unisot:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Bitcoin SV
+          </td>
+          <td>
+            <a href="https://www.unisot.com">UNISOT AS</a>
+          </td>
+          <td>
+            <a href="https://gitlab.com/unisot-did/unisot-did-method-specification">UNISOT DID Method</a>
+          </td>
+        </tr>
       </tbody>
     </table>
 


### PR DESCRIPTION
This is a request to add the UNISOT DID method for Bitcoin SV to the DID Spec Registry.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mirkostanic/did-spec-registries/pull/180.html" title="Last updated on Jan 7, 2021, 4:48 PM UTC (3eec032)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/180/b07450b...mirkostanic:3eec032.html" title="Last updated on Jan 7, 2021, 4:48 PM UTC (3eec032)">Diff</a>