### PR TITLE
editorial: remove explicit github req

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,8 +155,9 @@ specification [[DID-CORE]] is not entirely capable of addressing their use case
 and might need to add a new parameters, properties, or values to this registry
 in order to achieve their use case in a globally interoperable fashion. In order
 to add a new parameter, property, or value to this registry, an implementer MUST
-submit a modification request for this registry, as a GitHub Pull Request, where
-the modification request adheres to the following rules:
+submit a modification request for this registry, as a pull request on the
+repository where this registry is hosted, where the modification request adheres
+to the following rules:
     </p>
 
     <ol>


### PR DESCRIPTION
In case the Registries gets migrated to a different git platform in the distant future, I made "MUST ... github pull request" in the registration process more generic. This means that in the case of a move, the frontmatter of the doc with the links to repo can be updated, without having to worry about changes to 'normative' text, which might incur more process.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/181.html" title="Last updated on Jan 10, 2021, 3:53 PM UTC (a6b3265)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/181/b07450b...a6b3265.html" title="Last updated on Jan 10, 2021, 3:53 PM UTC (a6b3265)">Diff</a>