### PR TITLE
Add a JSON Schema for the core vocabulary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 coverage
+vocabs/shape_test.ttl
 
 .vscode
 .DS_Store

--- a/json_schemas/core.schema.json
+++ b/json_schemas/core.schema.json
@@ -107,7 +107,8 @@
                         "$ref" : "#/definitions/type.schema"
                     },
                     "verificationMethod" : {
-                        "$ref" : "#/definitions/verification_method.schema"
+                        "type": "string",
+                        "format" : "uri-reference"
                     },
                     "serviceEndpoint" : {
                         "oneOf" : [

--- a/json_schemas/core.schema.json
+++ b/json_schemas/core.schema.json
@@ -106,10 +106,6 @@
                     "type" : {
                         "$ref" : "#/definitions/type.schema"
                     },
-                    "verificationMethod" : {
-                        "type": "string",
-                        "format" : "uri-reference"
-                    },
                     "serviceEndpoint" : {
                         "oneOf" : [
                             {

--- a/json_schemas/core.schema.json
+++ b/json_schemas/core.schema.json
@@ -1,0 +1,185 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://w3c.github.io/did-spec-registries/schemas/core.schema.json",
+    "title": "DID Core Vocabulary schema",
+    "$comment": "The JWK.schema part is a copy of the JWK schema (https://preview.npmjs.com/package/jwk-schema), published by Jonathan Wilbur (https://github.com/JonathanWilbur)",
+    "definitions": {
+        "did.schema" : {
+            "type" : "string",
+            "pattern" : "^did:[a-z0-9]+:[a-zA-Z0-9.-_:]+"
+        },
+
+        "type.schema" : {
+            "type" : [
+                "string",
+                "array"
+            ],
+            "uniqueItems": true,
+            "items" : {
+                "type" : "string"
+            }
+        },
+
+        "JWK.schema" : {
+            "type" : "object",
+            "properties": {
+                "kty": {
+                    "type": "string"
+                },
+                "use": {
+                    "type": "string"
+                },
+                "key_ops": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "alg": {
+                    "type": "string"
+                },
+                "kid": {
+                    "type": "string"
+                },
+                "x5u": {
+                    "type": "string"
+                },
+                "x5c": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "x5t": {
+                    "type": "string"
+                },
+                "x5t#S256": {
+                    "type": "string"
+                }
+            },
+            "required": ["kty"],
+            "additionalProperties": true
+        },
+
+        "verification_method.schema" : {
+            "type" : "array",
+            "uniqueItems": true,
+            "items" : {
+                "type" : "object",
+                "properties": {
+                    "publicKeyJwk" : {
+                        "$ref" : "#/definitions/JWK.schema"
+                    },
+                    "publicKeyBase58" : {
+                        "type" : "string"
+                    },
+                    "controller" : {
+                        "$ref" : "#/definitions/did.schema"
+                    },
+                    "id" : {
+                        "type": "string",
+                        "format" : "uri-reference"
+                    },
+                    "type" : {
+                        "$ref" : "#/definitions/type.schema"
+                    }
+                },
+                "required" : ["id", "type", "controller"],
+                "oneOf": [
+                    {"required" : ["publicKeyJwk"]},
+                    {"required" : ["publicKeyBase58"]}
+                ],
+                "additionalProperties" : true
+            }
+        },
+
+        "service.schema" : {
+            "type" : "array",
+            "uniqueItems": true,
+            "items" : {
+                "type" : "object",
+                "properties" : {
+                    "id" : {
+                        "type" : "string",
+                        "format" : "uri-reference"
+                    },
+                    "type" : {
+                        "$ref" : "#/definitions/type.schema"
+                    },
+                    "verificationMethod" : {
+                        "$ref" : "#/definitions/verification_method.schema"
+                    },
+                    "serviceEndpoint" : {
+                        "oneOf" : [
+                            {
+                                "type": "string",
+                                "format" : "uri-reference"
+                            },
+                            {
+                                "type" : "object"
+                            },
+                            {
+                                "type" : "array",
+                                "uniqueItems": true,
+                                "items": {
+                                    "oneOf" : [
+                                        {
+                                            "type": "string",
+                                            "format" : "uri-reference"
+                                        },
+                                        {
+                                            "type" : "object"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                "required": ["id", "type", "serviceEndpoint"],
+                "additionalProperties" : true
+            }
+        }
+    },
+
+    "type": "object",
+    "properties": {
+        "id" : {
+            "$ref" : "#/definitions/did.schema"
+        },
+        "alsoKnownAs" : {
+            "type" : "array",
+            "uniqueItems": true,
+            "items": {
+                "type" : "string",
+                "format" : "uri-reference"
+            }
+        },
+        "controller" : {
+            "$ref" : "#/definitions/did.schema"
+        },
+        "verificationMethod" : {
+            "$ref" : "#/definitions/verification_method.schema"
+        },
+        "authentication" : {
+            "$ref" : "#/definitions/verification_method.schema"
+        },
+        "assertionMethod" : {
+            "$ref" : "#/definitions/verification_method.schema"
+        },
+        "keyAgreement" : {
+            "$ref" : "#/definitions/verification_method.schema"
+        },
+        "capabilityDelegation" : {
+            "$ref" : "#/definitions/verification_method.schema"
+        },
+        "capabilityInvocation" : {
+            "$ref" : "#/definitions/verification_method.schema"
+        },
+        "service" : {
+            "$ref" : "#/definitions/service.schema"
+        }
+    },
+    "required" : ["id"],
+    "additionalProperties" : true
+}


### PR DESCRIPTION
Adding [JSON Schema](https://json-schema.org/draft/2019-09/json-schema-core.html) for DID Documents using the JSON serialization. This PR is related to https://github.com/w3c/did-core/issues/404 (and also to https://github.com/w3c/did-core/pull/536).

The schema annotates/validates only those terms that are part of the DID Core specification. We have to decide whether:

1. extension terms should be added to the `core.schema.json`.
1. there should be one or several extra schema files for the extensions.

(I am mildly in favour of the second option)
