### PR TITLE
Fix specification link for did:morpheus

### DIFF
--- a/index.html
+++ b/index.html
@@ -3080,7 +3080,7 @@ address in the Author Links column, as this helps with maintenance.
             <a href="https://iop.global/">Internet of People</a>
           </td>
           <td>
-            <a href="https://developer.iop.global/#/w3c">Morpheus DID Method</a>
+            <a href="https://developer.iop.global/w3c">Morpheus DID Method</a>
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
Due to changes in the portal, the link to the specification has slightly changed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/izolyomi/did-spec-registries/pull/229.html" title="Last updated on Jan 19, 2021, 9:10 AM UTC (e4d286c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/229/464c874...izolyomi:e4d286c.html" title="Last updated on Jan 19, 2021, 9:10 AM UTC (e4d286c)">Diff</a>