### PR TITLE
contexts: Fix DID namespace URI

### DIFF
--- a/contexts/did-v1.html
+++ b/contexts/did-v1.html
@@ -76,7 +76,7 @@ provides a namespace so each term has an URI.
 Introduction
     </h1>
     <p>
-The DID Core v1.0 namespace URI is: <code>https://www.w3.org/ns/did/v1#</code>.
+The DID Core v1.0 namespace URI is: <code>https://www.w3.org/ns/did#</code>.
     </p>
     <p>
 This namespace contains the vocabulary terms used in the DID Core v1.0 data

--- a/contexts/did-v1.jsonld
+++ b/contexts/did-v1.jsonld
@@ -6,7 +6,7 @@
     "dc": "http://purl.org/dc/terms/",
     "schema": "http://schema.org/",
     "sec": "https://w3id.org/security#",
-    "didns": "https://www.w3.org/ns/did/v1#",
+    "didns": "https://www.w3.org/ns/did#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "EcdsaSecp256k1VerificationKey2019": "sec:EcdsaSecp256k1VerificationKey2019",
     "Ed25519Signature2018": "sec:Ed25519Signature2018",


### PR DESCRIPTION
I made a mistake in an earlier PR. While the correct URL for the JSON-LD context file is `https://www.w3.org/ns/did/v1`, the value for the RDF namespace is `https://www.w3.org/ns/did#`