### PR TITLE
parameters: Add resource param

### DIFF
--- a/index.html
+++ b/index.html
@@ -1895,6 +1895,28 @@ did:example:123?signed-ietf-json-patch=eyJraWQiOiJkaWQ6ZXhhbXBsZTo0NTYjX1FxMFVMM
       </pre>
     </section>
 
+    <section>
+      <h4 id="resource">resource</h4>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              TBC
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <pre class="example" title="A DID URL with a 'resource' DID parameter">
+did:foo:21tDAKCERh95uGgKbJNHYp?resource=true
+      </pre>
+    </section>
+
   </section>
 
   <section>


### PR DESCRIPTION
[Removed from the DID Core spec](https://github.com/w3c/did-core/pull/572), per resolution https://www.w3.org/2019/did-wg/Meetings/Minutes/2021-01-14-did-topic#resolution1

But afaik nobody has provided a document to define it yet, so this PR is incomplete. For reference, the definition from DID Core was:

> Indicates that the resource to be dereferenced is the <a>DID Subject</a>, rather
> than the <a>DID Document</a>. This parameter is used to retrieve an information
> resource identified by a <a>DID</a>. Support for this parameter is OPTIONAL.
> If present, the associated value MUST be the
> <a data-lt="ascii string">ASCII string</a> <code>true</code>.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/238.html" title="Last updated on Jan 23, 2021, 9:17 PM UTC (36056a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/238/9e243bb...36056a7.html" title="Last updated on Jan 23, 2021, 9:17 PM UTC (36056a7)">Diff</a>