### PR TITLE
Add orb DID method

### DIFF
--- a/index.html
+++ b/index.html
@@ -3449,6 +3449,23 @@ address in the Author Links column, as this helps with maintenance.
             <a href="https://github.com/Moonlight-io/specs/blob/master/did-method-spec.md">Vivid DID Method</a>
           </td>
         </tr>
+        <tr>
+          <td>
+            did:orb:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Ledger agnostic
+          </td>
+          <td>
+            <a href="https://securekey.com/">SecureKey</a>
+          </td>
+          <td>
+            <a href="https://trustbloc.github.io/did-method-orb/">Orb DID Method</a>
+          </td>
+        </tr>
       </tbody>
     </table>
 


### PR DESCRIPTION
The did:orb method specification.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/troyronda/did-spec-registries/pull/243.html" title="Last updated on Feb 1, 2021, 12:04 PM UTC (c7ad9d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/243/a1b73ad...troyronda:c7ad9d8.html" title="Last updated on Feb 1, 2021, 12:04 PM UTC (c7ad9d8)">Diff</a>