### PR TITLE
Re-sync the json schema with the spec

### DIFF
--- a/json_schemas/core.schema.json
+++ b/json_schemas/core.schema.json
@@ -61,34 +61,54 @@
             "additionalProperties": true
         },
 
-        "verification_method.schema" : {
+        "one_verification_method.schema" : {
+            "type" : "object",
+            "properties": {
+                "publicKeyJwk" : {
+                    "$ref" : "#/definitions/JWK.schema"
+                },
+                "publicKeyBase58" : {
+                    "type" : "string"
+                },
+                "controller" : {
+                    "$ref" : "#/definitions/did.schema"
+                },
+                "id" : {
+                    "type": "string",
+                    "format" : "uri-reference"
+                },
+                "type" : {
+                    "$ref" : "#/definitions/type.schema"
+                }
+            },
+            "required" : ["id", "type", "controller"],
+            "not": {
+                "required" : ["publicKeyJwk","publicKeyBase58"]
+            },
+            "additionalProperties" : true
+        },
+
+        "verification_method_strict.schema" : {
             "type" : "array",
             "uniqueItems": true,
             "items" : {
-                "type" : "object",
-                "properties": {
-                    "publicKeyJwk" : {
-                        "$ref" : "#/definitions/JWK.schema"
-                    },
-                    "publicKeyBase58" : {
-                        "type" : "string"
-                    },
-                    "controller" : {
-                        "$ref" : "#/definitions/did.schema"
-                    },
-                    "id" : {
+                "$ref" : "#/definitions/one_verification_method.schema"
+            }
+        },
+
+        "verification_method_with_urls.schema" : {
+            "type" : "array",
+            "uniqueItems": true,
+            "items" : {
+                "oneOf" : [
+                    {
                         "type": "string",
                         "format" : "uri-reference"
                     },
-                    "type" : {
-                        "$ref" : "#/definitions/type.schema"
+                    {
+                        "$ref" : "#/definitions/one_verification_method.schema"
                     }
-                },
-                "required" : ["id", "type", "controller"],
-                "not": {
-                    "required" : ["publicKeyJwk","publicKeyBase58"]
-                },
-                "additionalProperties" : true
+                ]
             }
         },
 
@@ -155,22 +175,22 @@
             "$ref" : "#/definitions/did.schema"
         },
         "verificationMethod" : {
-            "$ref" : "#/definitions/verification_method.schema"
+            "$ref" : "#/definitions/verification_method_strict.schema"
         },
         "authentication" : {
-            "$ref" : "#/definitions/verification_method.schema"
+            "$ref" : "#/definitions/verification_method_with_urls.schema"
         },
         "assertionMethod" : {
-            "$ref" : "#/definitions/verification_method.schema"
+            "$ref" : "#/definitions/verification_method_with_urls.schema"
         },
         "keyAgreement" : {
-            "$ref" : "#/definitions/verification_method.schema"
+            "$ref" : "#/definitions/verification_method_with_urls.schema"
         },
         "capabilityDelegation" : {
-            "$ref" : "#/definitions/verification_method.schema"
+            "$ref" : "#/definitions/verification_method_with_urls.schema"
         },
         "capabilityInvocation" : {
-            "$ref" : "#/definitions/verification_method.schema"
+            "$ref" : "#/definitions/verification_method_with_urls.schema"
         },
         "service" : {
             "$ref" : "#/definitions/service.schema"


### PR DESCRIPTION
The core spec makes it clear that there is a difference between the behavior of `verificationMethod`, whose value can only be an array of objects, and of the others (like `authentication`) that can also have a URI as a value (instead of the object). That distinction was not made in the json schema; done now.