### PR TITLE
adds table to support different context versions in the future

### DIFF
--- a/index.html
+++ b/index.html
@@ -1480,7 +1480,7 @@ represented as a <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
-              <th>@Context Values</th>
+              <th>`@context` Values</th>
               <th>Specification Version</th>
             </tr>
           </thead>

--- a/index.html
+++ b/index.html
@@ -1470,7 +1470,7 @@ These are entries in DID documents that are specific to the
         </table>
 
         <p>
-The following values are acceptable values for <code>@context</code> property as
+The following values are acceptable values for the <code>@context</code> entry as
 a <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON
   String</a> or first item of a <a
   href="https://tools.ietf.org/html/rfc8259#section-5">JSON Array</a>,

--- a/index.html
+++ b/index.html
@@ -1480,7 +1480,7 @@ represented as a <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
-              <th>@Context Values</th>
+              <th>@context Values</th>
             </tr>
           </thead>
           <tbody>

--- a/index.html
+++ b/index.html
@@ -1469,7 +1469,28 @@ These are entries in DID documents that are specific to the
           </tbody>
         </table>
 
-
+        <p>
+The following values are acceptable values for <code>@context</code> property as
+a <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON
+  String</a> or first item of a <a
+  href="https://tools.ietf.org/html/rfc8259#section-5">JSON Array</a>,
+represented as a <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON
+  String</a>.
+        </p>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>@Context Values</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://www.w3.org/ns/did/v1">https://www.w3.org/ns/did/v1</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
         <pre class="example" title="Example of @context in the JSON-LD representation">
 {

--- a/index.html
+++ b/index.html
@@ -1480,7 +1480,8 @@ represented as a <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
-              <th>@context Values</th>
+              <th>@Context Values</th>
+              <th>Specification Version</th>
             </tr>
           </thead>
           <tbody>
@@ -1488,7 +1489,9 @@ represented as a <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON
               <td>
                 <a href="https://www.w3.org/ns/did/v1">https://www.w3.org/ns/did/v1</a>
               </td>
-            </tr>
+              <td>
+                <a href="https://w3c.github.io/did-core/">DID Core 1.0 Working draft</a>
+              </td>
           </tbody>
         </table>
 


### PR DESCRIPTION
This coincides with PR https://github.com/w3c/did-core/pull/645 to help us avoid making normative errata changes when we want to update the context for did documents.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kdenhartog/did-core-registries/pull/251.html" title="Last updated on Mar 3, 2021, 1:41 AM UTC (c782c4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/251/bc9372e...kdenhartog:c782c4a.html" title="Last updated on Mar 3, 2021, 1:41 AM UTC (c782c4a)">Diff</a>