### PR TITLE
Change DID Core parameters to camelCase.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2004,7 +2004,7 @@ did:example:123?service=agent
     </section>
 
     <section>
-      <h4 id="version-id-param">version-id</h4>
+      <h4 id="versionId-param">versionId</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -2020,13 +2020,13 @@ did:example:123?service=agent
         </tbody>
       </table>
 
-      <pre class="example" title="Example of version-id parameter">
-did:example:123?version-id=4
+      <pre class="example" title="Example of versionId parameter">
+did:example:123?versionId=4
       </pre>
     </section>
 
     <section>
-      <h4 id="version-time-param">version-time</h4>
+      <h4 id="versionTime-param">versionTime</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -2042,13 +2042,13 @@ did:example:123?version-id=4
         </tbody>
       </table>
 
-      <pre class="example" title="Example of version-time parameter">
-did:example:123?version-time=2016-10-17T02:41:00Z
+      <pre class="example" title="Example of versionTime parameter">
+did:example:123?versionTime=2016-10-17T02:41:00Z
       </pre>
     </section>
 
     <section>
-      <h4 id="relative-ref-param">relative-ref</h4>
+      <h4 id="relativeRef-param">relativeRef</h4>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -2064,8 +2064,8 @@ did:example:123?version-time=2016-10-17T02:41:00Z
         </tbody>
       </table>
 
-      <pre class="example" title="Example of relative-ref parameter">
-did:example:123?service=files&relative-ref=%2Fmyresume%2Fdoc%3Fversion%3Dlatest%23intro
+      <pre class="example" title="Example of relativeRef parameter">
+did:example:123?service=files&relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlatest%23intro
       </pre>
     </section>
 


### PR DESCRIPTION
Parameters version-id, version-time, and relative-ref have been changed to camelCase in DID Core. This PR updates the registries accordingly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/256.html" title="Last updated on Feb 16, 2021, 9:25 PM UTC (7b0a403)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/256/81dc967...7b0a403.html" title="Last updated on Feb 16, 2021, 9:25 PM UTC (7b0a403)">Diff</a>