### PR TITLE
Move 'deactivated' to DID document metadata.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1745,30 +1745,6 @@ These properties contain information pertaining to the DID resolution response.
           </pre>
         </section>
 
-        <section>
-          <h4>deactivated</h4>
-          <table class="simple" style="width: 100%;">
-            <thead>
-              <tr>
-                <th>Normative Definition</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
-                  <a href="https://w3c.github.io/did-core/#did-resolution-metadata-properties">DID Core</a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-
-          <pre class="example" title="Example of deactivated error value">
-{
-  "error": "deactivated"
-}
-          </pre>
-        </section>
-
       </section>
     </section>
 
@@ -1845,6 +1821,40 @@ rather than the DID subject.
         <pre class="example" title="Example of updated property">
 {
   "updated": "2023-08-10T13:40:06Z"
+}
+        </pre>
+
+      </section>
+
+      <section>
+        <h4>deactivated</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON-LD</th>
+              <th>CDDL</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://www.w3.org/TR/did-core/#did-document-metadata-properties">DID Core</a>
+              </td>
+
+              <td>
+                <a href="https://www.w3.org/ns/did/v1">DID Core</a>
+              </td>
+              <td>
+                <a href="cddl/deactivated.cddl" target="_blank">deactivated.cddl</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of deactivated property">
+{
+  "deactivated": true
 }
         </pre>
 


### PR DESCRIPTION
Corresponds to https://github.com/w3c/did-core/pull/691.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/258.html" title="Last updated on Feb 22, 2021, 10:52 AM UTC (95cae4e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/258/81dc967...95cae4e.html" title="Last updated on Feb 22, 2021, 10:52 AM UTC (95cae4e)">Diff</a>