### PR TITLE
Register did:3

### DIFF
--- a/index.html
+++ b/index.html
@@ -2249,6 +2249,23 @@ address in the Author Links column, as this helps with maintenance.
       <tbody>
         <tr>
           <td>
+              did:3:
+          </td>
+          <td>
+              PROVISIONAL
+          </td>
+          <td>
+              Ceramic Network
+          </td>
+          <td>
+            <a href="mailto:oed@3box.io">Joel Thorstensson</a>
+          </td>
+          <td>
+            <a href="https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-79/CIP-79.md">3ID DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
               did:abt:
           </td>
           <td>
@@ -3152,6 +3169,23 @@ address in the Author Links column, as this helps with maintenance.
 
         <tr>
           <td>
+            did:onion:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Ledger agnostic
+          </td>
+          <td>
+            <a href="https://github.com/BlockchainCommons/did-method-onion">Blockchain Commons</a>
+          </td>
+          <td>
+            <a href="https://blockchaincommons.github.io/did-method-onion/">Onion DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
               did:ont:
           </td>
           <td>
@@ -3754,23 +3788,6 @@ address in the Author Links column, as this helps with maintenance.
           </td>
           <td>
             <a href="https://workday.github.io/work-did-method-spec/">Workday DID Method</a>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            did:onion:
-          </td>
-          <td>
-            PROVISIONAL
-          </td>
-          <td>
-            Ledger agnostic
-          </td>
-          <td>
-            <a href="https://github.com/BlockchainCommons/did-method-onion">Blockchain Commons</a>
-          </td>
-          <td>
-            <a href="https://blockchaincommons.github.io/did-method-onion/">Onion DID Method</a>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Registers the 3ID DID method used by 3Box and Ceramic.

Looks like `did:onion` was added out of order so I fixed that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ceramicnetwork/did-spec-registries/pull/260.html" title="Last updated on Mar 2, 2021, 10:12 AM UTC (fe8f6da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/260/dc4956e...ceramicnetwork:fe8f6da.html" title="Last updated on Mar 2, 2021, 10:12 AM UTC (fe8f6da)">Diff</a>