### PR TITLE
Add Tezos DID (did:tz) method specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -3533,6 +3533,23 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+						did:tz:
+					</td>
+					<td>
+						PROVISIONAL
+					</td>
+					<td>
+						DID Specification
+					</td>
+					<td>
+						<a href="https://spruceid.com">Spruce Systems, Inc.</a>
+					</td>
+					<td>
+						<a href="https://did-tezos.spruceid.com">Tezos DID Method</a>
+					</td>
+        </tr>
+        <tr>
+          <td>
             did:unik:
           </td>
           <td>


### PR DESCRIPTION
Adds the `did:tz` method specification.

http://did-tezos.spruceid.com/

You can find an implementation in Rust here:
https://github.com/spruceid/ssi/tree/main/did-tezos

DID Manager smart contract tooling is here:
https://github.com/spruceid/did-tezos


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/spruceid/did-spec-registries/pull/261.html" title="Last updated on Mar 3, 2021, 4:33 PM UTC (83a1105)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/261/dc4956e...spruceid:83a1105.html" title="Last updated on Mar 3, 2021, 4:33 PM UTC (83a1105)">Diff</a>