### PR TITLE
Register did:nft

### DIFF
--- a/index.html
+++ b/index.html
@@ -3134,6 +3134,23 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+              did:nft:
+          </td>
+          <td>
+              PROVISIONAL
+          </td>
+          <td>
+              Ceramic Network
+          </td>
+          <td>
+            <a href="mailto:oed@3box.io">Joel Thorstensson</a>
+          </td>
+          <td>
+            <a href="https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-94/CIP-94.md">NFT DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
               did:ockam:
           </td>
           <td>


### PR DESCRIPTION
The NFT DID is a new DID method created using the Ceramic network. It allows any NFT on any blockchain to be used as a DID where the asset owner becomes the controller of the DID.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ceramicnetwork/did-spec-registries/pull/262.html" title="Last updated on Mar 8, 2021, 8:45 AM UTC (c966b94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/262/dc4956e...ceramicnetwork:c966b94.html" title="Last updated on Mar 8, 2021, 8:45 AM UTC (c966b94)">Diff</a>