### PR TITLE
Fix author link for did:lit

### DIFF
--- a/index.html
+++ b/index.html
@@ -3859,7 +3859,7 @@ address in the Author Links column, as this helps with maintenance.
             LEDGIS
           </td>
           <td>
-            <a href="http://ibct.kr//">IBCT</a>
+            <a href="http://en.ibct.kr/">IBCT</a>
           </td>
           <td>
             <a href="https://github.com/ibct-dev/lit-DID/blob/main/docs/did:lit-method-spec_eng_v0.1.0.md">LIT DID Method</a>


### PR DESCRIPTION
The link to the author link has slightly changed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ibct-dev/did-spec-registries/pull/274.html" title="Last updated on Apr 2, 2021, 2:10 PM UTC (9e69bc2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/274/e3dd18c...ibct-dev:9e69bc2.html" title="Last updated on Apr 2, 2021, 2:10 PM UTC (9e69bc2)">Diff</a>