### PR TITLE
Add SOLID DID Method

### DIFF
--- a/FPWD/2020-06-18/index.html
+++ b/FPWD/2020-06-18/index.html
@@ -1982,6 +1982,24 @@ The links will be updated as subsequent Implementer’s Drafts are produced.
           </tr>
 
         <tr>
+            <td>
+                did:solid:
+            </td>
+            <td>
+                PROVISIONAL
+            </td>
+            <td>
+                Solana
+            </td>
+            <td>
+                <a href="https://github.com/dankelleher">Daniel Kelleher</a>
+            </td>
+            <td>
+                <a href="https://identity-com.github.io/solid-did/did-method-spec.html">SOLID DID Method</a>
+            </td>
+        </tr>
+        
+        <tr>
           <td>
               did:sov:
           </td>

--- a/cddl/did-document-simple.cddl
+++ b/cddl/did-document-simple.cddl
@@ -36,7 +36,8 @@ verificationMethod = publicKeyHex / ethereumAddress / publicKeyPem / publicKeyJw
 ;     "elastos" / "kilt" / "elem" / "github" / "bid" / "ptn" / "echo" / 
 ;     "trustbloc" / "san" / "gatc" / "factom" / "signor" / "hedera" / 
 ;     "sirius" / "dock" / "twit" / "near" / "vaa" / "bba" / "morpheus" / 
-;     "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key"
+;     "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key" /
+;     "solid"
 
 
 ;;; 

--- a/cddl/did-document.cddl
+++ b/cddl/did-document.cddl
@@ -45,8 +45,8 @@ verificationMethod = publicKeyHex / ethereumAddress / publicKeyPem / publicKeyJw
 ;     "elastos" / "kilt" / "elem" / "github" / "bid" / "ptn" / "echo" / 
 ;     "trustbloc" / "san" / "gatc" / "factom" / "signor" / "hedera" / 
 ;     "sirius" / "dock" / "twit" / "near" / "vaa" / "bba" / "morpheus" / 
-;     "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key"
-
+;     "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key" /
+;     "solid"
 
 
 ;;; 

--- a/cddl/method-name.cddl
+++ b/cddl/method-name.cddl
@@ -9,4 +9,5 @@ method-name =
     "elastos" / "kilt" / "elem" / "github" / "bid" / "ptn" / "echo" / 
     "trustbloc" / "san" / "gatc" / "factom" / "signor" / "hedera" / 
     "sirius" / "dock" / "twit" / "near" / "vaa" / "bba" / "morpheus" / 
-    "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key"
+    "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key" /
+    "solid"

--- a/index.html
+++ b/index.html
@@ -3451,6 +3451,25 @@ address in the Author Links column, as this helps with maintenance.
               <a href="https://gitlab.com/proximax-enterprise/siriusid/sirius-id-specs/-/blob/master/docs/did-method-spec.md">ProximaX SiriusID DID Method</a>
           </td>
         </tr>
+
+        <tr>
+            <td>
+                did:solid:
+            </td>
+            <td>
+                PROVISIONAL
+            </td>
+            <td>
+                Solana
+            </td>
+            <td>
+                <a href="https://github.com/dankelleher">Daniel Kelleher</a>
+            </td>
+            <td>
+                <a href="https://identity-com.github.io/solid-did/did-method-spec.html">SOLID DID Method</a>
+            </td>
+        </tr>
+
         <tr>
           <td>
               did:sov:


### PR DESCRIPTION
Add the SOLID DID Method, based on the Solana blockchain, to the did spec registry.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/identity-com/did-spec-registries/pull/276.html" title="Last updated on Mar 27, 2021, 6:27 AM UTC (5b76a59)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/276/e3dd18c...identity-com:5b76a59.html" title="Last updated on Mar 27, 2021, 6:27 AM UTC (5b76a59)">Diff</a>