### PR TITLE
Update to Candidate Recommendation JSON-LD Context.

### DIFF
--- a/vocabs/v1/context.jsonld
+++ b/vocabs/v1/context.jsonld
@@ -54,8 +54,7 @@
     },
     "verificationMethod": {
       "@id": "https://w3id.org/security#verificationMethod",
-      "@type": "@id",
-      "@container": "@set"
+      "@type": "@id"
     }
   }
 }

--- a/vocabs/v1/context.jsonld
+++ b/vocabs/v1/context.jsonld
@@ -1,89 +1,59 @@
 {
   "@context": {
-    "@version": 1.1,
+    "@protected": true,
     "id": "@id",
     "type": "@type",
-    "dc": "http://purl.org/dc/terms/",
-    "schema": "http://schema.org/",
-    "sec": "https://w3id.org/security#",
-    "didns": "https://www.w3.org/ns/did#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "EcdsaSecp256k1VerificationKey2019": "sec:EcdsaSecp256k1VerificationKey2019",
-    "Ed25519Signature2018": "sec:Ed25519Signature2018",
-    "Ed25519VerificationKey2018": "sec:Ed25519VerificationKey2018",
-    "JsonWebKey2020": "sec:JsonWebKey2020",
-    "JsonWebSignature2020": "sec:JsonWebSignature2020",
-    "Bls12381G1Key2020": "sec:Bls12381G1Key2020",
-    "Bls12381G2Key2020": "sec:Bls12381G2Key2020",
-    "RsaVerificationKey2018": "sec:RsaVerificationKey2018",
-    "SchnorrSecp256k1VerificationKey2019": "sec:SchnorrSecp256k1VerificationKey2019",
-    "X25519KeyAgreementKey2019": "sec:X25519KeyAgreementKey2019",
-    "ServiceEndpointProxyService": "didns:ServiceEndpointProxyService",
-    "LinkedDomains": "https://identity.foundation/.well-known/resources/did-configuration/#LinkedDomains",
+
     "alsoKnownAs": {
       "@id": "https://www.w3.org/ns/activitystreams#alsoKnownAs",
       "@type": "@id",
       "@container": "@set"
     },
     "assertionMethod": {
-      "@id": "sec:assertionMethod",
+      "@id": "https://w3id.org/security#assertionMethod",
       "@type": "@id",
       "@container": "@set"
     },
     "authentication": {
-      "@id": "sec:authenticationMethod",
+      "@id": "https://w3id.org/security#authenticationMethod",
       "@type": "@id",
       "@container": "@set"
     },
     "capabilityDelegation": {
-      "@id": "sec:capabilityDelegationMethod",
+      "@id": "https://w3id.org/security#capabilityDelegationMethod",
       "@type": "@id",
       "@container": "@set"
     },
     "capabilityInvocation": {
-      "@id": "sec:capabilityInvocationMethod",
+      "@id": "https://w3id.org/security#capabilityInvocationMethod",
       "@type": "@id",
       "@container": "@set"
     },
     "controller": {
-      "@id": "sec:controller",
+      "@id": "https://w3id.org/security#controller",
       "@type": "@id"
     },
-    "created": {
-      "@id": "dc:created",
-      "@type": "xsd:dateTime"
-    },
-    "blockchainAccountId": "sec:blockchainAccountId",
     "keyAgreement": {
-      "@id": "sec:keyAgreementMethod",
+      "@id": "https://w3id.org/security#keyAgreementMethod",
       "@type": "@id",
       "@container": "@set"
-    },
-    "publicKey": {
-      "@id": "sec:publicKey",
-      "@type": "@id",
-      "@container": "@set"
-    },
-    "publicKeyBase58": "sec:publicKeyBase58",
-    "publicKeyJwk": {
-      "@id": "sec:publicKeyJwk",
-      "@type": "@json"
     },
     "service": {
-      "@id": "didns:service",
+      "@id": "https://www.w3.org/ns/did#service",
       "@type": "@id",
-      "@container": "@set"
-    },
-    "serviceEndpoint": {
-      "@id": "didns:serviceEndpoint",
-      "@type": "@id"
-    },
-    "updated": {
-      "@id": "dc:modified",
-      "@type": "xsd:dateTime"
+      "@container": "@set",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "serviceEndpoint": {
+          "@id": "https://www.w3.org/ns/did#serviceEndpoint",
+          "@type": "@id"
+        }
+      }
     },
     "verificationMethod": {
-      "@id": "sec:verificationMethod",
+      "@id": "https://w3id.org/security#verificationMethod",
       "@type": "@id"
     }
   }

--- a/vocabs/v1/context.jsonld
+++ b/vocabs/v1/context.jsonld
@@ -6,8 +6,7 @@
 
     "alsoKnownAs": {
       "@id": "https://www.w3.org/ns/activitystreams#alsoKnownAs",
-      "@type": "@id",
-      "@container": "@set"
+      "@type": "@id"
     },
     "assertionMethod": {
       "@id": "https://w3id.org/security#assertionMethod",
@@ -41,7 +40,6 @@
     "service": {
       "@id": "https://www.w3.org/ns/did#service",
       "@type": "@id",
-      "@container": "@set",
       "@context": {
         "@protected": true,
         "id": "@id",

--- a/vocabs/v1/context.jsonld
+++ b/vocabs/v1/context.jsonld
@@ -54,7 +54,8 @@
     },
     "verificationMethod": {
       "@id": "https://w3id.org/security#verificationMethod",
-      "@type": "@id"
+      "@type": "@id",
+      "@container": "@set"
     }
   }
 }


### PR DESCRIPTION
The WG forgot to update the Candidate Recommendation JSON-LD Context to something that didn't have gaping security holes before we entered CR (the current context allows redefinition, which let's you switch things like verification relationships). This was a fairly major oversight, this PR attempts to fix that. :)

This PR assumes that the JSON-LD Context ONLY contains context values that are specified in the DID Core specification. It doesn't include the cryptosuites because different DID Methods will make different choices there (some will chose to only use pure Ed25519 or Koblitz, while others will support the JOSE version of Koblitz, while others will pull in the kitchen sink). Same with service types. The expectation here is that DID Methods will specify at least ONE extra Method-specific context, and that's where they will specify cryptosuites and services supported by the DID Method.

DB has done some light testing on this JSON-LD Context. We need more eyes on it to make sure it's what we want.