### PR TITLE
Fix capitalization of metadata property names.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1683,7 +1683,7 @@ These properties contain information pertaining to the DID resolution request.
 These properties contain information pertaining to the DID resolution response.
     </p>
     <section>
-      <h3>content-type</h3>
+      <h3>contentType</h3>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -1699,15 +1699,15 @@ These properties contain information pertaining to the DID resolution response.
             </td>
             <td></td>
             <td>
-              <a href="cddl/contentType.cddl" target="_blank">content-type.cddl</a>
+              <a href="cddl/contentType.cddl" target="_blank">contentType.cddl</a>
             </td>
           </tr>
         </tbody>
       </table>
 
-      <pre class="example" title="Example of content-type metadata property">
+      <pre class="example" title="Example of contentType metadata property">
 {
-  "content-type": "application/did+ld+json"
+  "contentType": "application/did+ld+json"
 }
       </pre>
     </section>
@@ -1738,12 +1738,12 @@ These properties contain information pertaining to the DID resolution response.
 
       <pre class="example" title="Example of error metadata property">
 {
-  "error": "not-found"
+  "error": "notFound"
 }
       </pre>
 
       <section>
-        <h4>invalid-did</h4>
+        <h4>invalidDid</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1759,15 +1759,15 @@ These properties contain information pertaining to the DID resolution response.
           </tbody>
         </table>
 
-        <pre class="example" title="Example of invalid-did error value">
+        <pre class="example" title="Example of invalidDid error value">
 {
-  "error": "invalid-did"
+  "error": "invalidDid"
 }
         </pre>
       </section>
 
       <section>
-        <h4>invalid-did-url</h4>
+        <h4>invalidDidUrl</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1783,15 +1783,15 @@ These properties contain information pertaining to the DID resolution response.
           </tbody>
         </table>
 
-        <pre class="example" title="Example of invalid-did-url error value">
+        <pre class="example" title="Example of invalidDidUrl error value">
 {
-  "error": "invalid-did-url"
+  "error": "invalidDidUrl"
 }
         </pre>
       </section>
 
       <section>
-        <h4>not-found</h4>
+        <h4>notFound</h4>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1807,9 +1807,9 @@ These properties contain information pertaining to the DID resolution response.
           </tbody>
         </table>
 
-        <pre class="example" title="Example of not-found error value">
+        <pre class="example" title="Example of notFound error value">
 {
-  "error": "not-found"
+  "error": "notFound"
 }
         </pre>
       </section>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/278.html" title="Last updated on Apr 1, 2021, 7:10 PM UTC (f8d4e50)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/278/977ce9a...f8d4e50.html" title="Last updated on Apr 1, 2021, 7:10 PM UTC (f8d4e50)">Diff</a>