### PR TITLE
Add did:did DID method

### DIFF
--- a/index.html
+++ b/index.html
@@ -2490,6 +2490,23 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+            did:did:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Decentralized Identitifiers
+          </td>
+          <td>
+            <a href="https://spruceid.com">Spruce Systems, Inc.</a>
+          </td>
+          <td>
+            <a href="https://did-did.spruceid.com">DID Identity DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
             did:dock:
           </td>
           <td>


### PR DESCRIPTION
This adds `did:did`, a DID method for Decentralized Identifiers (DIDs).

Editor's draft: https://did-did.spruceid.com/
Source: https://github.com/spruceid/did-did/
Announcement: https://www.w3.org/mid/20210401163331.0603f198@spruceid.com


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/spruceid/did-spec-registries/pull/280.html" title="Last updated on Apr 1, 2021, 9:06 PM UTC (71f792e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/280/3a97169...spruceid:71f792e.html" title="Last updated on Apr 1, 2021, 9:06 PM UTC (71f792e)">Diff</a>