### PR TITLE
Remove schema language requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,18 +216,7 @@ feature to eliminate the possibility of term conflicts.
       <li>
 Properties in the DID Core Registries MUST NOT be removed, only deprecated.
       </li>
-      <li>
-Properties defined in the DID Core Registries MUST include a Concise Data
-Definition Language (CDDL) [[RFC8610]] of the Property and its Abstract Data
-Model structure.
-      </li>
     </ol>
-
-    <p class="issue">
-Should CDDL be used as the Data Definition Language to formalize the constraints
-of the CBOR and JSON representation of a DID document? (see <a
-href="https://github.com/w3c/did-spec-registries/issues/153">issue #153</a>).
-    </p>
 
     <p>
 The Editors of the DID Specification Registries MUST consider all of the


### PR DESCRIPTION
Per #264

This PR begins the registration cleanup process, which ends in #285.

These PRs build on each other, but I believe ultimately all should be merged to improve the registry.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/283.html" title="Last updated on Apr 3, 2021, 3:55 PM UTC (d5a7127)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/283/59b9869...d5a7127.html" title="Last updated on Apr 3, 2021, 3:55 PM UTC (d5a7127)">Diff</a>