### PR TITLE
marking did:git as withdrawn

### DIFF
--- a/index.html
+++ b/index.html
@@ -2743,19 +2743,19 @@ address in the Author Links column, as this helps with maintenance.
           </td>
         </tr>
         <tr>
-          <td>
+          <td style="text-decoration:line-through">
             did:git:
           </td>
-          <td>
-            PROVISIONAL
+          <td style="color:#FF0000">
+            WITHDRAWN
           </td>
-          <td>
+          <td style="text-decoration:line-through">
             DID Specification
           </td>
-          <td>
+          <td style="text-decoration:line-through">
             Internet Identity Workshop
           </td>
-          <td>
+          <td style="text-decoration:line-through">
             <a href="https://github.com/dhuseby/did-git-spec/blob/master/did-git-spec.md">Git DID Method</a>
           </td>
         </tr>


### PR DESCRIPTION
Signed-off-by: Dave Huseby <dwh@trustframe.com>

I am marking the did:git method spec as WITHDRAWN because developer identity provenance in Git repos is being implemented using [authentic data provenance logs](https://github.com/TrustFrame/authentic-data-specifications/blob/main/Authentic%20Data%20Provenance%20Log.md) instead of DID documents simply because the DID specs are [unusable](https://dwhuseby.medium.com/dont-use-dids-58759823378c).

As the primary author of did:git, I wish to formally withdraw the did:git spec from the registry. I will leave the spec up for posterity but it is officially deprecated.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dhuseby/did-spec-registries/pull/288.html" title="Last updated on Apr 13, 2021, 6:29 PM UTC (317ac1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/288/043fdc1...dhuseby:317ac1e.html" title="Last updated on Apr 13, 2021, 6:29 PM UTC (317ac1e)">Diff</a>