### PR TITLE
Add SOL DID Method

### DIFF
--- a/cddl/did-document-simple.cddl
+++ b/cddl/did-document-simple.cddl
@@ -36,7 +36,8 @@ verificationMethod = publicKeyHex / ethereumAddress / publicKeyPem / publicKeyJw
 ;     "elastos" / "kilt" / "elem" / "github" / "bid" / "ptn" / "echo" / 
 ;     "trustbloc" / "san" / "gatc" / "factom" / "signor" / "hedera" / 
 ;     "sirius" / "dock" / "twit" / "near" / "vaa" / "bba" / "morpheus" / 
-;     "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key"
+;     "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key" /
+;     "sol"
 
 
 ;;; 

--- a/cddl/did-document.cddl
+++ b/cddl/did-document.cddl
@@ -45,8 +45,8 @@ verificationMethod = publicKeyHex / ethereumAddress / publicKeyPem / publicKeyJw
 ;     "elastos" / "kilt" / "elem" / "github" / "bid" / "ptn" / "echo" / 
 ;     "trustbloc" / "san" / "gatc" / "factom" / "signor" / "hedera" / 
 ;     "sirius" / "dock" / "twit" / "near" / "vaa" / "bba" / "morpheus" / 
-;     "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key"
-
+;     "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key" /
+;     "sol"
 
 
 ;;; 

--- a/cddl/method-name.cddl
+++ b/cddl/method-name.cddl
@@ -9,4 +9,5 @@ method-name =
     "elastos" / "kilt" / "elem" / "github" / "bid" / "ptn" / "echo" / 
     "trustbloc" / "san" / "gatc" / "factom" / "signor" / "hedera" / 
     "sirius" / "dock" / "twit" / "near" / "vaa" / "bba" / "morpheus" / 
-    "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key"
+    "etho" / "bnb" / "celo" / "klay" / "trx" / "grg" / "schema" / "key" /
+    "sol"

--- a/index.html
+++ b/index.html
@@ -3452,6 +3452,23 @@ address in the Author Links column, as this helps with maintenance.
           </td>
         </tr>
         <tr>
+            <td>
+                did:sol:
+            </td>
+            <td>
+                PROVISIONAL
+            </td>
+            <td>
+                Solana
+            </td>
+            <td>
+                <a href="https://github.com/dankelleher">Daniel Kelleher</a>
+            </td>
+            <td>
+                <a href="https://identity-com.github.io/sol-did/did-method-spec.html">SOL DID Method</a>
+            </td>
+        </tr>
+        <tr>
           <td>
               did:sov:
           </td>


### PR DESCRIPTION
Note to reviewers - this replaces an old PR: https://github.com/w3c/did-spec-registries/pull/276 .

The method name was changed from SOLID to SOL to avoid clashes with  https://solidproject.org/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/identity-com/did-spec-registries/pull/290.html" title="Last updated on Apr 19, 2021, 6:11 PM UTC (2ec5d3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/290/e3dd18c...identity-com:2ec5d3e.html" title="Last updated on Apr 19, 2021, 6:11 PM UTC (2ec5d3e)">Diff</a>