### PR TITLE
Add SSB DID method

### DIFF
--- a/index.html
+++ b/index.html
@@ -3549,6 +3549,23 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+            did:ssb:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Secure Scuttlebutt
+          </td>
+          <td>
+            Charles E. Lehner
+          </td>
+          <td>
+            <a href="https://viewer.scuttlebot.io/&amp;5Bne/slGKH/i1361qemVlNBElWInSUfntlWvMXaD4M4=.sha256?hl=zQmdh4Ya6WasmjnS4UMn5ot6k5tbCypy1oyhhdJ6yB6MjfT">SSB DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
             did:stack:
           </td>
           <td>


### PR DESCRIPTION
This PR adds a specification to the registry for a SSB (Secure Scuttlebutt) DID method, `did:ssb:`.

Since the [registration process](https://w3c.github.io/did-spec-registries/#the-registration-process) encourages using content-integrity-protected links, this PR links to the current version of the specification, with a [hashlink](https://w3c-ccg.github.io/hashlink/):
<https://viewer.scuttlebot.io/&5Bne/slGKH/i1361qemVlNBElWInSUfntlWvMXaD4M4=.sha256?hl=zQmdh4Ya6WasmjnS4UMn5ot6k5tbCypy1oyhhdJ6yB6MjfT>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clehner/did-spec-registries/pull/291.html" title="Last updated on May 8, 2021, 12:22 AM UTC (62eab7c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/291/4682f2e...clehner:62eab7c.html" title="Last updated on May 8, 2021, 12:22 AM UTC (62eab7c)">Diff</a>