### PR TITLE
Register TLS DID Method

### DIFF
--- a/index.html
+++ b/index.html
@@ -3543,6 +3543,24 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+            did:tls:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Ethereum
+          </td>
+          <td>
+            Ulrich Gallersdörfer, Kilian Käslin
+          </td>
+          <td>
+            <a href="https://github.com/digitalcredentials/tls-did/blob/master/doc/did-method-spec.md">TLS DID
+              Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
             did:trustbloc:
           </td>
           <td>


### PR DESCRIPTION
This pull request adds the TLS DID Method.

Spec: [https://github.com/digitalcredentials/tls-did/blob/master/doc/did-method-spec.md](https://github.com/digitalcredentials/tls-did/blob/master/doc/did-method-spec.md)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/KilianKae/did-spec-registries/pull/292.html" title="Last updated on Apr 27, 2021, 8:01 AM UTC (d084781)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/292/7806755...KilianKae:d084781.html" title="Last updated on Apr 27, 2021, 8:01 AM UTC (d084781)">Diff</a>