### PR TITLE
Register did:safe

### DIFF
--- a/index.html
+++ b/index.html
@@ -3419,7 +3419,7 @@ address in the Author Links column, as this helps with maintenance.
             <a href="mailto:safe@gnosis.io">Gnosis Ltd.</a>
           </td>
           <td>
-            <a href="https://github.com/ceramicnetwork/CIP/issues/101">SAFE DID Method</a>
+            <a href="https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-101/CIP-101.md">SAFE DID Method</a>
           </td>
         </tr>
         <tr>

--- a/index.html
+++ b/index.html
@@ -3407,6 +3407,23 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+            did:safe:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Gnosis Safe
+          </td>
+          <td>
+            <a href="mailto:safe@gnosis.io">Gnosis Ltd.</a>
+          </td>
+          <td>
+            <a href="https://github.com/ceramicnetwork/CIP/issues/101">SAFE DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
             did:san:
           </td>
           <td>


### PR DESCRIPTION
The SAFE DID is a new DID method created using the Ceramic network. It allows any [Gnosis Safe](https://gnosis-safe.io/) smart contract wallet on any EVM based blockchain to be used as a DID where the owners becomes the controller of the DID.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gnosis/did-spec-registries/pull/294.html" title="Last updated on Apr 27, 2021, 10:28 AM UTC (8eee111)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/294/7806755...gnosis:8eee111.html" title="Last updated on Apr 27, 2021, 10:28 AM UTC (8eee111)">Diff</a>