### PR TITLE
Add TRUST DID (did:trust) method specification.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3595,6 +3595,23 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+            did:trust:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            TrustChain
+          </td>
+          <td>
+            TrustCerts GmbH
+          </td>
+          <td>
+            <a href="https://github.com/trustcerts/did-trust-method/blob/main/README.md">Trust DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
             did:trustbloc:
           </td>
           <td>


### PR DESCRIPTION
Adds the did:trust method specification

https://github.com/trustcerts/did-trust-method/blob/main/README.md


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/trustcerts/did-spec-registries/pull/297.html" title="Last updated on May 4, 2021, 6:52 AM UTC (6d7630d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/297/ee5b852...trustcerts:6d7630d.html" title="Last updated on May 4, 2021, 6:52 AM UTC (6d7630d)">Diff</a>