### PR TITLE
Add IOTA DID (did:iota) method specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -2903,6 +2903,23 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+            did:iota:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            IOTA
+          </td>
+          <td>
+            <a href="https://iota.org">IOTA Foundation</a>
+          </td>
+          <td>
+            <a href="https://github.com/iotaledger/identity.rs/blob/main/docs/specs/iota_did_method_spec.md">IOTA DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
             did:ipid:
           </td>
           <td>


### PR DESCRIPTION
Adds the did:iota method specification to the overview. Method spec can be found [here](https://github.com/iotaledger/identity.rs/blob/main/docs/specs/iota_did_method_spec.md).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JelleMillenaar/did-spec-registries/pull/300.html" title="Last updated on May 10, 2021, 3:26 PM UTC (e7cd08b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/300/116c472...JelleMillenaar:e7cd08b.html" title="Last updated on May 10, 2021, 3:26 PM UTC (e7cd08b)">Diff</a>