### PR TITLE
Add DIDCommMessaging service type

### DIFF
--- a/index.html
+++ b/index.html
@@ -1488,7 +1488,6 @@ in a service object.
 
       <section>
         <h4>DIDCommMessaging</h4>
-        <div class="issue" data-number="167"></div>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1513,22 +1512,23 @@ in a service object.
         </table>
 
         <pre class="example" title="Example of service and serviceEndpoint properties">
-      {
-        "@context":[
-            "https://www.w3.org/ns/did/v1",
-            "https://didcomm.org/messaging/contexts/v2"
-        ],
-        "id":"did:example:123456789abcdefghi#didcomm-1",
-        "type":"DIDCommMessaging",
-        "serviceEndpoint":"http://example.com/path",
-        "accept":[
-            "didcomm/v2",
-            "didcomm/aip2;env=rfc587"
-        ],
-        "routingKeys":[
-            "did:example:somemediator#somekey"
-        ]
-      }
+{
+  "@context":[
+      "https://www.w3.org/ns/did/v1",
+      "https://didcomm.org/messaging/contexts/v2"
+  ],
+  ...
+  "type":"DIDCommMessaging",
+  "serviceEndpoint":"http://example.com/path",
+  "accept":[
+      "didcomm/v2",
+      "didcomm/aip2;env=rfc587"
+  ],
+  "routingKeys":[
+      "did:example:somemediator#somekey"
+  ]
+  ...
+}
         </pre>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -1499,7 +1499,7 @@ in a service object.
           <tbody>
             <tr>
               <td>
-                <a href="https://didcomm.org/messaging/v2">DIDComm Messaging</a>
+                <a href="https://didcomm.org/messaging/v2/">DIDComm Messaging</a>
               </td>
               <td>
                 <a href="https://didcomm.org/messaging/contexts/v2">DIDComm Messaging</a>

--- a/index.html
+++ b/index.html
@@ -1486,6 +1486,51 @@ in a service object.
 
       </section>
 
+      <section>
+        <h4>DIDCommMessaging</h4>
+        <div class="issue" data-number="167"></div>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON-LD</th>
+              <th>CDDL</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://didcomm.org/messaging/v2">DIDComm Messaging</a>
+              </td>
+              <td>
+                <a href="https://didcomm.org/messaging/contexts/v2">DIDComm Messaging</a>
+              </td>
+              <td>
+                <span>CDDL definition pending</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of service and serviceEndpoint properties">
+      {
+        "@context":[
+            "https://www.w3.org/ns/did/v1",
+            "https://didcomm.org/messaging/contexts/v2"
+        ],
+        "id":"did:example:123456789abcdefghi#didcomm-1",
+        "type":"DIDCommMessaging",
+        "serviceEndpoint":"http://example.com/path",
+        "accept":[
+            "didcomm/v2",
+            "didcomm/aip2;env=rfc587"
+        ],
+        "routingKeys":[
+            "did:example:somemediator#somekey"
+        ]
+      }
+        </pre>
+
       </section>
 
   </section>


### PR DESCRIPTION
Adding DIDCommMessaging service type

*updated*: removed WIP


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/awoie/did-spec-registries/pull/301.html" title="Last updated on May 11, 2021, 11:02 AM UTC (ad7aa9b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/301/116c472...awoie:ad7aa9b.html" title="Last updated on May 11, 2021, 11:02 AM UTC (ad7aa9b)">Diff</a>