### PR TITLE
Add 'representationNotSupported' error.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1829,6 +1829,30 @@ These properties contain information pertaining to the DID resolution response.
         </pre>
       </section>
 
+      <section>
+        <h4>representationNotSupported</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c.github.io/did-core/#did-resolution-metadata">DID Core</a>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of representationNotSupported error value">
+{
+  "error": "representationNotSupported"
+}
+        </pre>
+      </section>
+
     </section>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -1840,7 +1840,7 @@ These properties contain information pertaining to the DID resolution response.
           <tbody>
           <tr>
             <td>
-              <a href="https://w3c.github.io/did-core/#did-resolution-metadata">DID Core</a>
+              <a href="https://www.w3.org/TR/did-core/#did-resolution-metadata">DID Core</a>
             </td>
           </tr>
           </tbody>


### PR DESCRIPTION
Fixes https://github.com/w3c/did-spec-registries/issues/305.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/306.html" title="Last updated on May 25, 2021, 8:41 AM UTC (0eab939)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/306/c3044b7...0eab939.html" title="Last updated on May 25, 2021, 8:41 AM UTC (0eab939)">Diff</a>