### PR TITLE
Add 'equivalentId' and 'canonicalId'.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2045,6 +2045,74 @@ rather than the DID subject.
       </pre>
 
     </section>
+
+    <section>
+      <h3>equivalentId</h3>
+      <table class="simple" style="width: 100%;">
+        <thead>
+        <tr>
+          <th>Normative Definition</th>
+          <th>JSON-LD</th>
+          <th>CDDL</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td>
+            <a href="https://www.w3.org/TR/did-core/#did-document-metadata-properties">DID Core</a>
+          </td>
+
+          <td>
+            <a href="https://www.w3.org/ns/did/v1">DID Core</a>
+          </td>
+          <td>
+            <a href="cddl/equivalentId.cddl" target="_blank">equivalentId.cddl</a>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+
+      <pre class="example" title="Example of equivalentId property">
+{
+  "equivalentId": ["did:example:ABC", "did:example:Abc"]
+}
+      </pre>
+
+    </section>
+
+    <section>
+      <h3>canonicalId</h3>
+      <table class="simple" style="width: 100%;">
+        <thead>
+        <tr>
+          <th>Normative Definition</th>
+          <th>JSON-LD</th>
+          <th>CDDL</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td>
+            <a href="https://www.w3.org/TR/did-core/#did-document-metadata-properties">DID Core</a>
+          </td>
+
+          <td>
+            <a href="https://www.w3.org/ns/did/v1">DID Core</a>
+          </td>
+          <td>
+            <a href="cddl/canonicalId.cddl" target="_blank">canonicalId.cddl</a>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+
+      <pre class="example" title="Example of canonicalId property">
+{
+  "canonicalId": "did:example:ABC"
+}
+      </pre>
+
+    </section>
   </section>
 
   <section>


### PR DESCRIPTION
Fixes https://github.com/w3c/did-spec-registries/issues/232.