### PR TITLE
Add SSW DID method

### DIFF
--- a/index.html
+++ b/index.html
@@ -3729,6 +3729,23 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+            did:ssw:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Initial Network
+          </td>
+          <td>
+            <a href="https://www.sktelecom.com/index_en.html">SK telecom</a>
+          </td>
+          <td>
+            <a href="https://sktston.github.io/ssw-did/did-method-spec.html">SSW DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
             did:stack:
           </td>
           <td>


### PR DESCRIPTION
This PR adds a specification to the registry for a SSW (Self Sovereign Wallet) DID method, `did:ssw:`.

Please refer to the link below for the specification.
https://sktston.github.io/ssw-did/did-method-spec.html

Thanks!
Signed-off-by: Ethan Sung <baegjae@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/baegjae/did-spec-registries/pull/312.html" title="Last updated on Jun 10, 2021, 6:01 AM UTC (1753784)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/312/a87a4a5...baegjae:1753784.html" title="Last updated on Jun 10, 2021, 6:01 AM UTC (1753784)">Diff</a>