### PR TITLE
Add EOSIO DID method

### DIFF
--- a/index.html
+++ b/index.html
@@ -2760,6 +2760,23 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+            did:eosio:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            EOSIO
+          </td>
+          <td>
+            <a href="https://gimly.io">Gimly Blockchain</a>
+          </td>
+          <td>
+            <a href="https://github.com/Gimly-Blockchain/eosio-did-spec">EOSIO DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
             did:evan:
           </td>
           <td>


### PR DESCRIPTION
This PR adds the `did:eosio:` DID method to the registry.

[https://github.com/Gimly-Blockchain/eosio-did-spec](https://github.com/Gimly-Blockchain/eosio-did-spec)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Gimly-Blockchain/did-spec-registries/pull/315.html" title="Last updated on Jun 17, 2021, 10:14 AM UTC (3fa84d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/315/49e1d75...Gimly-Blockchain:3fa84d8.html" title="Last updated on Jun 17, 2021, 10:14 AM UTC (3fa84d8)">Diff</a>