### PR TITLE
Added LACChain DID method

### DIFF
--- a/index.html
+++ b/index.html
@@ -4186,6 +4186,23 @@ address in the Author Links column, as this helps with maintenance.
             <a href="https://workday.github.io/work-did-method-spec/">Workday DID Method</a>
           </td>
         </tr>
+        <tr>
+          <td>
+            did:lac:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            LACChain Network
+          </td>
+          <td>
+            LACChain Alliance
+          </td>
+          <td>
+            <a href="https://github.com/lacchain/lacchain-did-registry/blob/master/DID_SPEC.md">LAC DID Method</a>
+          </td>
+        </tr>
       </tbody>
     </table>
 


### PR DESCRIPTION
This PR adds the did:lac: DID method to the registry.
https://github.com/lacchain/lacchain-did-registry/blob/master/DID_SPEC.md


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sergioceron/did-spec-registries/pull/317.html" title="Last updated on Jun 23, 2021, 1:56 AM UTC (5a577ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/317/49e1d75...sergioceron:5a577ec.html" title="Last updated on Jun 23, 2021, 1:56 AM UTC (5a577ec)">Diff</a>