### PR TITLE
Polygon-DID method specification addition to registry

### DIFF
--- a/index.html
+++ b/index.html
@@ -4275,23 +4275,6 @@ address in the Author Links column, as this helps with maintenance.
             <a href="https://workday.github.io/work-did-method-spec/">Workday DID Method</a>
           </td>
         </tr>
-        <tr>
-          <td>
-            did:polygon:
-          </td>
-          <td>
-            PROVISIONAL
-          </td>
-          <td>
-            Polygon (Previously MATIC)
-          </td>
-          <td>
-            Ayanworks, MATIC
-          </td>
-          <td>
-            <a href="https://github.com/ayanworks/polygon-did-method-spec">Polygon DID Method</a>
-          </td>
-        </tr>
       </tbody>
     </table>
 

--- a/index.html
+++ b/index.html
@@ -3665,6 +3665,23 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+            did:polygon:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Polygon (Previously MATIC)
+          </td>
+          <td>
+            Ayanworks, MATIC
+          </td>
+          <td>
+            <a href="https://github.com/ayanworks/polygon-did-method-spec">Polygon DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
             did:ptn:
           </td>
           <td>

--- a/index.html
+++ b/index.html
@@ -3674,7 +3674,7 @@ address in the Author Links column, as this helps with maintenance.
             Polygon (Previously MATIC)
           </td>
           <td>
-            Ayanworks, MATIC
+            AyanWorks, MATIC
           </td>
           <td>
             <a href="https://github.com/ayanworks/polygon-did-method-spec">Polygon DID Method</a>


### PR DESCRIPTION
This request is to add Polygon-DID method specification to the DID spec registry.
Files changed:
index.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/anushaayanworks/did-spec-registries/pull/318.html" title="Last updated on Jul 13, 2021, 5:30 AM UTC (8a53133)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/318/7b60ed6...anushaayanworks:8a53133.html" title="Last updated on Jul 13, 2021, 5:30 AM UTC (8a53133)">Diff</a>