### PR TITLE
Fix representation registration links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1544,19 +1544,7 @@ in a service object.
         <tr id="application-did-cbor">
           <td>application/did+cbor</td>
           <td>
-            <a href="https://www.w3.org/TR/did-core#cbor">DID Core</a>
-          </td>
-        </tr>
-        <tr id="application-did-dag-cbor">
-          <td>application/did+dag+cbor</td>
-          <td>
-            <p class="issue" data-number="252"></p>
-          </td>
-        </tr>
-        <tr id="application-did-yaml">
-          <td>application/did+yaml</td>
-          <td>
-            <p class="issue" data-number="253"></p>
+            <a href="https://www.w3.org/TR/did-cbor-representation/#application-did-cbor">The Plain CBOR Representation</a>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/325.html" title="Last updated on Jul 27, 2021, 11:14 PM UTC (81889a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/325/ad0f3cc...81889a8.html" title="Last updated on Jul 27, 2021, 11:14 PM UTC (81889a8)">Diff</a>