### PR TITLE
Use camelCase for parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -2212,7 +2212,7 @@ did:example:123?service=files&amp;relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlate
     </section>
 
     <section>
-      <h3 id="initial-state-param">initial-state</h3>
+      <h3 id="initialState-param">initialState</h3>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -2228,13 +2228,13 @@ did:example:123?service=files&amp;relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlate
         </tbody>
       </table>
 
-      <pre class="example" title="Example of initial-state parameter">
-did:example:123?initial-state=eyJkZWx0YV9oYXNoIjoiRWlDUlRKZ2Q0U0V2YUZDLW9fNUZjQnZJUkRtWF94Z3RLX3g...
+      <pre class="example" title="Example of initialState parameter">
+did:example:123?initialState=eyJkZWx0YV9oYXNoIjoiRWlDUlRKZ2Q0U0V2YUZDLW9fNUZjQnZJUkRtWF94Z3RLX3g...
       </pre>
     </section>
 
     <section>
-      <h3 id="transform-keys-param">transform-keys</h3>
+      <h3 id="transformKeys-param">transformKeys</h3>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -2250,13 +2250,13 @@ did:example:123?initial-state=eyJkZWx0YV9oYXNoIjoiRWlDUlRKZ2Q0U0V2YUZDLW9fNUZjQn
         </tbody>
       </table>
 
-      <pre class="example" title="Example of transform-keys parameter">
-did:example:123?transform-keys=jwk
+      <pre class="example" title="Example of transformKeys parameter">
+did:example:123?transformKeys=jwk
       </pre>
     </section>
 
     <section>
-      <h3 id="signed-ietf-json-patch-param">signed-ietf-json-patch</h3>
+      <h3 id="signedIetfJsonPatch-param">signedIetfJsonPatch</h3>
       <table class="simple" style="width: 100%;">
         <thead>
           <tr>
@@ -2272,8 +2272,8 @@ did:example:123?transform-keys=jwk
         </tbody>
       </table>
 
-      <pre class="example" title="Example of signed-ietf-json-patch parameter">
-did:example:123?signed-ietf-json-patch=eyJraWQiOiJkaWQ6ZXhhbXBsZTo0NTYjX1FxMFVMMkZxNjUxUTBGamQ2VH...
+      <pre class="example" title="Example of signedIetfJsonPatch parameter">
+did:example:123?signedIetfJsonPatch=eyJraWQiOiJkaWQ6ZXhhbXBsZTo0NTYjX1FxMFVMMkZxNjUxUTBGamQ2VH...
       </pre>
     </section>
 


### PR DESCRIPTION
This changes the remaining 3 DID URL parameters to camelCase, also see:

https://github.com/w3c/did-spec-registries/issues/239


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/326.html" title="Last updated on Jul 28, 2021, 5:56 PM UTC (24779d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/326/ad0f3cc...24779d6.html" title="Last updated on Jul 28, 2021, 5:56 PM UTC (24779d6)">Diff</a>