### PR TITLE
Add PML DID Specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -4189,6 +4189,23 @@ address in the Author Links column, as this helps with maintenance.
             <a href="https://github.com/lacchain/lacchain-did-registry/blob/master/DID_SPEC.md">LAC DID Method</a>
           </td>
         </tr>
+        <tr>
+          <td>
+            did:pml:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            PML Chain
+          </td>
+          <td>
+            Purple Mountain Laboratories
+          </td>
+          <td>
+            <a href="https://github.com/PML-ID/pml-did-specs/blob/main/did-method.md">PML DID Method</a>
+          </td>
+        </tr>
       </tbody>
     </table>
 


### PR DESCRIPTION
We are staffs of Purple Mountain Laboratories and we hope register DID specifications


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/PML-ID/did-spec-registries/pull/331.html" title="Last updated on Aug 17, 2021, 10:04 AM UTC (390063a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/331/d504775...PML-ID:390063a.html" title="Last updated on Aug 17, 2021, 10:04 AM UTC (390063a)">Diff</a>