### PR TITLE
change registry columns per issue #83

### DIFF
--- a/index.html
+++ b/index.html
@@ -2391,15 +2391,17 @@ will not be accepted. We encourage DID method authors to provide an email
 address in the Author Links column, as this helps with maintenance. 
 If an email address is omitted, a label noting that there is no 
 contact information for the author will be applied to the registry entry.
+The registry is not for historical purposes, so when a when v1.0-compliant 
+Method Spec link is available, the Pre-v1.0 column MUST be made empty.
     </p>
 
     <table class="simple">
       <thead>
         <tr>
           <th>Method Name</th>
-          <th>DLT or Network</th>
+          <th>Verifiable Data Registry</th>
           <th>Author Links</th>
-          <th>Pre‑v1.0 PROVISIONAL Draft Link <br>(when best available, otherwise empty)</th>
+          <th>Pre‑v1.0 Method Spec Link</th>
           <th>v1.0‑Compliant Method Spec Link</th>
           <th>Notes</th>
         </tr>

--- a/index.html
+++ b/index.html
@@ -2393,16 +2393,15 @@ If an email address is omitted, a label noting that there is no
 contact information for the author will be applied to the registry entry.
     </p>
 
-
-
     <table class="simple">
       <thead>
         <tr>
           <th>Method Name</th>
-          <th>Status</th>
           <th>DLT or Network</th>
           <th>Author Links</th>
-          <th>Link</th>
+          <th>Pre‑v1.0 PROVISIONAL Draft Link <br>(when best available, otherwise empty)</th>
+          <th>v1.0‑Compliant Method Spec Link</th>
+          <th>Notes</th>
         </tr>
       </thead>
 
@@ -2410,9 +2409,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:3:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ceramic Network
@@ -2423,13 +2419,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-79/CIP-79.md">3ID DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:abt:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             ABT Network
@@ -2440,13 +2438,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://arcblock.github.io/abt-did-spec/">ABT DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:aergo:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             <a href="https://www.aergo.io/">Aergo</a>
@@ -2457,13 +2457,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/aergoio/aergo-identity/blob/master/doc/did-method-spec.md">Aergo DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ala:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Alastria
@@ -2474,13 +2476,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/alastria/alastria-identity/wiki/Alastria-DID-Method-Specification-(Quorum-version)">Alastria DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:amo:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             AMO blockchain mainnet
@@ -2491,13 +2495,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/amolabs/docs/blob/master/amo-did.md">AMO DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:bba:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ardor
@@ -2508,13 +2514,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/blobaa/bba-did-method-specification/blob/master/docs/markdown/spec.md">BBA DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:bid:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             bif
@@ -2525,13 +2533,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/teleinfo-bif/bid/tree/master/doc/en">BIF DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:bnb:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Binance Smart Chain
@@ -2542,13 +2552,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ontology-tech/DID-method-specs/blob/master/did-bnb/DID-Method-bnb.md">Binance DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:bryk:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             bryk
@@ -2559,13 +2571,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/bryk-io/did-method/blob/master/README.md">bryk DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:btcr:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Bitcoin
@@ -2576,13 +2590,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://w3c-ccg.github.io/didm-btcr">BTCR DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ccp:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Quorum
@@ -2593,13 +2609,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://did.baidu.com/did-spec/">Cloud DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:celo:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Celo
@@ -2610,13 +2628,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ontology-tech/DID-method-specs/blob/master/did-celo/DID-Method-celo.md">Celo DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:com:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             commercio.network
@@ -2627,13 +2647,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/commercionetwork/Commercio.network-DID-Method-Specification/">Commercio.network DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:corda:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Corda
@@ -2644,13 +2666,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://htmlpreview.github.io/?https://github.com/persistentsystems/corda-did-method/blob/master/corda_did_method.html">Corda DID method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:did:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Decentralized Identifiers
@@ -2661,13 +2685,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://did-did.spruceid.com">DID Identity DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:dns:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Domain Name System (DNS)
@@ -2678,13 +2704,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://danubetech.github.io/did-method-dns/">DNS DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:dock:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Dock
@@ -2695,13 +2723,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/docknetwork/dock-did-driver/blob/master/Dock%20DID%20method%20specification.md">Dock DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:dom:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -2711,13 +2741,15 @@ contact information for the author will be applied to the registry entry.
           </td>
           <td>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:dual:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -2728,13 +2760,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/Smart-ID-Card/Dual-DID/blob/main/docs/dual-did-method.md">Dual DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:echo:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Echo
@@ -2745,13 +2779,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/echoprotocol/uni-resolver-driver-did-echo/blob/master/echo_did_specifications.md">Echo DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:elastos:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Elastos ID Sidechain
@@ -2762,13 +2798,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/elastos/Elastos.DID.Method/blob/master/DID/Elastos-DID-Method-Specification_en.md">Elastos DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:elem:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Element DID
@@ -2779,13 +2817,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/decentralized-identity/element/blob/master/docs/did-method-spec/spec.md">ELEM DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:emtrust:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Hyperledger Fabric
@@ -2796,13 +2836,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/Halialabs/did-spec/blob/gh-pages/readme.md">Emtrust DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ens:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -2813,13 +2855,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/veramolabs/did-ens-spec">ENS DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>        
         <tr>
           <td>
             did:eosio:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             EOSIO
@@ -2830,13 +2874,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/Gimly-Blockchain/eosio-did-spec">EOSIO DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:erc725:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -2847,13 +2893,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/WebOfTrustInfo/rebooting-the-web-of-trust-spring2018/blob/master/topics-and-advance-readings/DID-Method-erc725.md">erc725 DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:etho:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -2864,13 +2912,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ontology-tech/DID-method-specs/blob/master/did-etho/DID-Method-etho.md">ETHO DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ethr:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -2881,13 +2931,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md">ETHR DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:evan:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             evan.network
@@ -2898,13 +2950,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/evannetwork/evan.network-DID-method-specification/blob/master/evan_did_method_spec.md">evan.network DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:example:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             DID Specification
@@ -2915,13 +2969,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://w3c-ccg.github.io/did-spec/">DID Specification</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:factom:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Factom
@@ -2932,13 +2988,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/factom-protocol/FIS/blob/master/FIS/DID.md">Factom DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:future:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Netease Chain
@@ -2949,13 +3007,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/netease-chain/Future-DID-Method-Specification/blob/main/README.md">Future DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:gatc:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum, Hyperledger Fabric, Hyperledger Besu, Alastria
@@ -2966,30 +3026,35 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/gatacaid/gataca-did-method">Gataca DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
-          <td style="text-decoration:line-through">
+          <td>
             did:git:
           </td>
-          <td style="color:#FF0000">
-            WITHDRAWN
-          </td>
-          <td style="text-decoration:line-through">
+          <td>
             DID Specification
           </td>
-          <td style="text-decoration:line-through">
+          <td>
             Internet Identity Workshop
           </td>
-          <td style="text-decoration:line-through">
+          <td>
             <a href="https://github.com/dhuseby/did-git-spec/blob/master/did-git-spec.md">Git DID Method</a>
+          </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+            DEPRECATED
           </td>
         </tr>
         <tr>
           <td>
             did:github:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Github
@@ -3000,13 +3065,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://docs.github-did.com/did-method-spec/">GitHub DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:grg:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             GrgChain
@@ -3017,13 +3084,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/GrgChain/DID-method-specs/blob/master/README.md">GrgChain DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:hedera:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Hedera Hashgraph
@@ -3034,13 +3103,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/hashgraph/did-method/blob/master/did-method-specification.md">Hedera Hashgraph DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:holo:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Holochain
@@ -3051,13 +3122,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/WebOfTrustInfo/rwot9-prague/blob/master/draft-documents/did:hc-method.md">Holochain DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:hpass:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Hyperledger Fabric
@@ -3068,13 +3141,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/IBM/hpass/blob/main/doc/did-spec.md">hpass DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:icon:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             ICON
@@ -3085,13 +3160,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/icon-project/icon-DID/blob/master/docs/ICON-DID-method.md">ICON DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
             <td>
                 did:infra:
-            </td>
-            <td>
-                PROVISIONAL
             </td>
             <td>
                 <a href="https://infrablockchain.com">InfraBlockchain</a>
@@ -3102,13 +3179,15 @@ contact information for the author will be applied to the registry entry.
             <td>
                 <a href="https://github.com/InfraBlockchain/infra-did-method-specs/blob/main/docs/Infra-DID-method-spec.md">Infra DID Method</a>
             </td>
+            <td>
+              noncompliant
+            </td>
+            <td>
+            </td>
         </tr>
         <tr>
           <td>
             did:io:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             IoTeX
@@ -3119,13 +3198,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/iotexproject/iotex-did/blob/master/README.md">IoTeX DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ion:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Bitcoin
@@ -3136,13 +3217,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/decentralized-identity/ion-did-method">ION DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:iota:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             IOTA
@@ -3153,13 +3236,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/iotaledger/identity.rs/blob/main/docs/specs/iota_did_method_spec.md">IOTA DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ipid:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             IPFS
@@ -3170,13 +3255,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://did-ipid.github.io/ipid-did-method/">IPID DID method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:is:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Blockcore
@@ -3187,13 +3274,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/block-core/blockcore-did-method">Blockcore DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:iwt:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             InfoWallet
@@ -3204,13 +3293,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/infowallet/did_method/blob/master/did_method.md">InfoWallet DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:jlinc:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             JLINC Protocol
@@ -3221,13 +3312,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://did-spec.jlinc.org/">JLINC Protocol DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:jnctn:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Jnctn Network
@@ -3238,13 +3331,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/jnctn/did-method-spec/">JNCTN DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:jolo:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -3255,13 +3350,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/jolocom/jolo-did-method/blob/master/jolocom-did-method-specification.md">Jolocom DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:keri:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ledger agnostic
@@ -3272,13 +3369,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://identity.foundation/keri/did_methods/">KERI DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:key:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ledger independent DID method based on public/private key pairs
@@ -3289,13 +3388,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://w3c-ccg.github.io/did-method-key/">DID key method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:kilt:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             KILT Blockchain
@@ -3306,13 +3407,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/KILTprotocol/kilt-did-driver/blob/master/DID%20Method%20Specification.md">KILT DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:klay:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Klaytn
@@ -3323,13 +3426,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ontology-tech/DID-method-specs/blob/master/did-klay/DID-Method-klay.md">Klaytn DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:kr:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Korea Mobile Identity System
@@ -3340,13 +3445,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/identify202020/did-method/blob/main/did_kr_method.md">Korea Mobile Identity System DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:lac:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             LACChain Network
@@ -3357,13 +3464,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/lacchain/lacchain-did-registry/blob/master/DID_SPEC.md">LAC DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:life:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             RChain
@@ -3374,13 +3483,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://lifeid.github.io/did-method-spec/">lifeID DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:lit:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             LEDGIS
@@ -3391,13 +3502,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ibct-dev/lit-DID/blob/main/docs/did:lit-method-spec_eng_v0.1.0.md">LIT DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:meme:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ledger agnostic
@@ -3408,13 +3521,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/OR13/didme.me#did-method-spec">Meme DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:meta:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Metadium
@@ -3425,13 +3540,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/METADIUM/meta-DID/blob/master/doc/DID-method-metadium.md">Metadium DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:moac:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             MOAC
@@ -3442,13 +3559,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/DavidRicardoWilde/moac-did/blob/master/did-moac-method.md">MOAC DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:monid:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -3459,13 +3578,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://lianxi-tech.github.io/monid/">MONiD DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:morpheus:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Hydra
@@ -3476,13 +3597,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://developer.iop.global/w3c">Morpheus DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:mydata:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             iGrant.io
@@ -3493,13 +3616,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/decentralised-dataexchange/automated-data-agreements/blob/main/docs/did-spec.md">Data Agreement DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:near:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             NEAR
@@ -3510,13 +3635,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ontology-tech/DID-spec-near/blob/master/NEAR/DID-Method-NEAR.md">NEAR DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:nft:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ceramic Network
@@ -3527,13 +3654,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-94/CIP-94.md">NFT DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ockam:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ockam
@@ -3544,13 +3673,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ockam-network/did-method-spec/blob/master/README.md">Ockam DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:omn:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             OmniOne
@@ -3561,13 +3692,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/OmniOneID/did_method/blob/master/did_method.md">OmniOne DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:onion:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ledger agnostic
@@ -3578,13 +3711,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://blockchaincommons.github.io/did-method-onion/">Onion DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ont:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ontology
@@ -3595,13 +3730,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ontio/ontology-DID/blob/master/docs/en/DID-ONT-method.md">Ontology DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:op:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ocean Protocol
@@ -3612,13 +3749,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/oceanprotocol/OEPs/blob/master/7/v0.2/README.md">Ocean Protocol DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:orb:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ledger agnostic
@@ -3629,13 +3768,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://trustbloc.github.io/did-method-orb/">Orb DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:panacea:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Panacea
@@ -3646,13 +3787,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/medibloc/panacea-core/blob/master/docs/did.md">Panacea DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:peer:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             peer
@@ -3663,13 +3806,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://identity.foundation/peer-did-method-spec/index.html">peer DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:pistis:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -3680,13 +3825,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/uino95/ssi/blob/consensys/dashboard/server/pistis/pistis-did-resolver/README.md">Pistis DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:pkh:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ledger-independent generative DID method based on CAIP-10 keypair expressions
@@ -3697,13 +3844,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/spruceid/ssi/blob/9ecc25cb4082709d146206b779cf8e8442f9eaf3/did-pkh/did-pkh-method-draft.md">did:pkh method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:pml:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             PML Chain
@@ -3714,13 +3863,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/PML-ID/pml-did-specs/blob/main/did-method.md">PML DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:polygon:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Polygon (Previously MATIC)
@@ -3731,13 +3882,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ayanworks/polygon-did-method-spec">Polygon DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ptn:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             PalletOne
@@ -3748,13 +3901,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/palletone/palletone-DID/blob/master/docs/did-method/README.md">PalletOne DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:safe:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Gnosis Safe
@@ -3765,13 +3920,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-101/CIP-101.md">SAFE DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:san:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             SAN Cloudchain
@@ -3782,13 +3939,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/Baasze/DID-method-specification">SAN DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:schema:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Multiple storage networks, currently public IPFS and evan.network IPFS
@@ -3799,13 +3958,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/51nodes/schema-registry-did-method/blob/master/README.md">Schema Registry DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:selfkey:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -3816,13 +3977,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/SelfKeyFoundation/selfkey-identity/blob/develop/DIDMethodSpecs.md">SelfKey DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:sideos:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ledger agnostic
@@ -3833,13 +3996,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/sideos/sideos-did-method">sideos DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:signor:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum, Hedera Hashgraph, Quorum, Hyperledger Besu
@@ -3850,13 +4015,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/cryptonicsconsulting/signor-did-contracts/blob/master/did-method-spec.md">Signor DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:sirius:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             ProximaX Sirius Chain
@@ -3867,13 +4034,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://gitlab.com/proximax-enterprise/siriusid/sirius-id-specs/-/blob/master/docs/did-method-spec.md">ProximaX SiriusID DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
             <td>
                 did:sol:
-            </td>
-            <td>
-                PROVISIONAL
             </td>
             <td>
                 Solana
@@ -3884,13 +4053,15 @@ contact information for the author will be applied to the registry entry.
             <td>
                 <a href="https://identity-com.github.io/sol-did/did-method-spec.html">SOL DID Method</a>
             </td>
+            <td>
+              noncompliant
+            </td>
+            <td>
+            </td>
         </tr>
         <tr>
           <td>
             did:sov:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Sovrin
@@ -3901,13 +4072,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://sovrin-foundation.github.io/sovrin/spec/did-method-spec-template.html">Sovrin DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ssb:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Secure Scuttlebutt
@@ -3918,13 +4091,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://viewer.scuttlebot.io/&amp;5Bne/slGKH/i1361qemVlNBElWInSUfntlWvMXaD4M4=.sha256?hl=zQmdh4Ya6WasmjnS4UMn5ot6k5tbCypy1oyhhdJ6yB6MjfT">SSB DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ssw:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Initial Network
@@ -3935,13 +4110,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://sktston.github.io/ssw-did/did-method-spec.html">SSW DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:stack:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Bitcoin
@@ -3952,13 +4129,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/blockstack/blockstack-core/blob/stacks-1.0/docs/blockstack-did-spec.md">Blockstack DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:tangle:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             IOTA Tangle
@@ -3969,13 +4148,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/TangleID/TangleID/blob/develop/did-method-spec.md">TangleID DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:tls:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -3987,13 +4168,15 @@ contact information for the author will be applied to the registry entry.
             <a href="https://github.com/digitalcredentials/tls-did/blob/master/doc/did-method-spec.md">TLS DID
               Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:trust:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             TrustChain
@@ -4004,13 +4187,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/trustcerts/did-trust-method/blob/main/README.md">Trust DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:trustbloc:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Hyperledger Fabric
@@ -4021,13 +4206,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/trustbloc/trustbloc-did-method/blob/master/docs/spec/trustbloc-did-method.md">TrustBloc DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:trx:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             TRON
@@ -4038,13 +4225,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/ontology-tech/DID-method-specs/blob/master/did-trx/DID-Method-trx.md">TRON DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:ttm:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             TMChain
@@ -4055,13 +4244,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/TokenTM/TM-DID/blob/master/docs/en/DID_spec.md">TM DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:twit:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Twit
@@ -4072,13 +4263,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://did-twit.github.io/did-twit/">Twit DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:tyron:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Zilliqa
@@ -4089,13 +4282,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://www.tyronzil.com">tyronZIL DID-Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:tys:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             DID Specification
@@ -4106,13 +4301,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/chainyard-tys/tys/blob/master/README.md">TYS DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:tz:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Tezos
@@ -4123,13 +4320,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://did-tezos.spruceid.com">Tezos DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:unik:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             <a href="https://docs.uns.network/">uns.network</a>
@@ -4140,13 +4339,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/unik-name/did-method-spec/blob/main/did-unik/UNIK-DID-Specification.md">UNIK DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:unisot:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Bitcoin SV
@@ -4157,13 +4358,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://gitlab.com/unisot-did/unisot-did-method-specification">UNISOT DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:uns:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             <a href="https://docs.uns.network/">uns.network</a>
@@ -4174,13 +4377,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/unik-name/did-method-spec/blob/main/did-uns/UNS-DID-Specification.md">UNS DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:uport:
-          </td>
-          <td>
-            DEPRECATED
           </td>
           <td>
             Ethereum
@@ -4190,13 +4395,16 @@ contact information for the author will be applied to the registry entry.
           </td>
           <td>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+            DEPRECATED
+          </td>
         </tr>
         <tr>
           <td>
             did:v1:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Veres One
@@ -4207,13 +4415,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://w3c-ccg.github.io/did-method-v1/">Veres One DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:vaa:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             bif
@@ -4224,13 +4434,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/caict-develop-zhangbo/vaa-method/blob/master/README.md">VAA Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:vaultie:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -4241,13 +4453,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/vaultie/vaultie-did-method/blob/master/vaultie-did-method-specification.md">Vaultie DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:vid:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             VP
@@ -4258,13 +4472,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/vpayment/did-method-spec/blob/master/vid.md">VP DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:vivid:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             NEO2, NEO3, Zilliqa
@@ -4275,13 +4491,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/Moonlight-io/specs/blob/master/did-method-spec.md">Vivid DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:vvo:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Vivvo
@@ -4292,13 +4510,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://vivvo.github.io/vivvo-did-scheme/spec/did-method-spec-template.html">Vivvo DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:web:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Web
@@ -4309,13 +4529,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://github.com/w3c-ccg/did-method-web">Web DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:wlk:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Weelink Network
@@ -4326,13 +4548,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://weelink-team.github.io/weelink/DIDDesignEn">Weelink DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
         <tr>
           <td>
             did:work:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Hyperledger Fabric
@@ -4343,10 +4567,15 @@ contact information for the author will be applied to the registry entry.
           <td>
             <a href="https://workday.github.io/work-did-method-spec/">Workday DID Method</a>
           </td>
+          <td>
+            noncompliant
+          </td>
+          <td>
+          </td>
         </tr>
       </tbody>
     </table>
-
+    
   </section>
 
 </body>


### PR DESCRIPTION
The following changes are for [issue 83](/w3c/did-spec-registries/issues/83#issuecomment-924061109):

- add a (blank) column to the table of DID Methods which would link to their updated-for-1.0 DID Method spec
- remove "Status: PROVISIONAL" column
- label old links as pre-1.0 versions
- add notes column for author-submitted status changes
- rename WITHDRAWN status to DEPRECATED, per spec
- remove strikeout from deprecated/withdrawn did:git


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rxgrant/did-spec-registries/pull/341.html" title="Last updated on Oct 12, 2021, 1:12 PM UTC (2fb4113)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/341/c934b5d...rxgrant:2fb4113.html" title="Last updated on Oct 12, 2021, 1:12 PM UTC (2fb4113)">Diff</a>