### PR TITLE
Remove did:github due to lack of feedback 

### DIFF
--- a/index.html
+++ b/index.html
@@ -2986,23 +2986,6 @@ contact information for the author will be applied to the registry entry.
         </tr>
         <tr>
           <td>
-            did:github:
-          </td>
-          <td>
-            PROVISIONAL
-          </td>
-          <td>
-            Github
-          </td>
-          <td>
-            Transmute
-          </td>
-          <td>
-            <a href="https://docs.github-did.com/did-method-spec/">GitHub DID Method</a>
-          </td>
-        </tr>
-        <tr>
-          <td>
             did:grg:
           </td>
           <td>


### PR DESCRIPTION
per https://github.com/w3c/did-spec-registries/issues/94


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/345.html" title="Last updated on Oct 19, 2021, 4:01 PM UTC (cd32a9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/345/c934b5d...cd32a9a.html" title="Last updated on Oct 19, 2021, 4:01 PM UTC (cd32a9a)">Diff</a>