### PR TITLE
Remove PROVISIONAL status from all DID method registrations

### DIFF
--- a/index.html
+++ b/index.html
@@ -2399,7 +2399,6 @@ contact information for the author will be applied to the registry entry.
       <thead>
         <tr>
           <th>Method Name</th>
-          <th>Status</th>
           <th>DLT or Network</th>
           <th>Author Links</th>
           <th>Link</th>
@@ -2410,9 +2409,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:3:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ceramic Network
@@ -2429,9 +2425,6 @@ contact information for the author will be applied to the registry entry.
             did:abt:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             ABT Network
           </td>
           <td>
@@ -2444,9 +2437,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:aergo:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             <a href="https://www.aergo.io/">Aergo</a>
@@ -2463,9 +2453,6 @@ contact information for the author will be applied to the registry entry.
             did:ala:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Alastria
           </td>
           <td>
@@ -2478,9 +2465,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:amo:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             AMO blockchain mainnet
@@ -2497,9 +2481,6 @@ contact information for the author will be applied to the registry entry.
             did:bba:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ardor
           </td>
           <td>
@@ -2512,9 +2493,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:bid:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             bif
@@ -2531,9 +2509,6 @@ contact information for the author will be applied to the registry entry.
             did:bnb:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Binance Smart Chain
           </td>
           <td>
@@ -2546,9 +2521,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:bryk:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             bryk
@@ -2565,9 +2537,6 @@ contact information for the author will be applied to the registry entry.
             did:btcr:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Bitcoin
           </td>
           <td>
@@ -2580,9 +2549,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:ccp:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Quorum
@@ -2599,9 +2565,6 @@ contact information for the author will be applied to the registry entry.
             did:celo:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Celo
           </td>
           <td>
@@ -2614,9 +2577,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:com:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             commercio.network
@@ -2633,9 +2593,6 @@ contact information for the author will be applied to the registry entry.
             did:corda:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Corda
           </td>
           <td>
@@ -2648,9 +2605,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:did:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Decentralized Identifiers
@@ -2667,9 +2621,6 @@ contact information for the author will be applied to the registry entry.
             did:dns:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Domain Name System (DNS)
           </td>
           <td>
@@ -2682,9 +2633,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:dock:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Dock
@@ -2701,9 +2649,6 @@ contact information for the author will be applied to the registry entry.
             did:dom:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ethereum
           </td>
           <td>
@@ -2715,9 +2660,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:dual:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -2734,9 +2676,6 @@ contact information for the author will be applied to the registry entry.
             did:echo:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Echo
           </td>
           <td>
@@ -2749,9 +2688,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:elastos:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Elastos ID Sidechain
@@ -2768,9 +2704,6 @@ contact information for the author will be applied to the registry entry.
             did:elem:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Element DID
           </td>
           <td>
@@ -2783,9 +2716,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:emtrust:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Hyperledger Fabric
@@ -2802,9 +2732,6 @@ contact information for the author will be applied to the registry entry.
             did:ens:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ethereum
           </td>
           <td>
@@ -2817,9 +2744,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:eosio:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             EOSIO
@@ -2836,9 +2760,6 @@ contact information for the author will be applied to the registry entry.
             did:erc725:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ethereum
           </td>
           <td>
@@ -2851,9 +2772,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:etho:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -2870,9 +2788,6 @@ contact information for the author will be applied to the registry entry.
             did:ethr:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ethereum
           </td>
           <td>
@@ -2885,9 +2800,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:evan:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             evan.network
@@ -2904,9 +2816,6 @@ contact information for the author will be applied to the registry entry.
             did:example:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             DID Specification
           </td>
           <td>
@@ -2919,9 +2828,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:factom:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Factom
@@ -2938,9 +2844,6 @@ contact information for the author will be applied to the registry entry.
             did:future:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Netease Chain
           </td>
           <td>
@@ -2955,9 +2858,6 @@ contact information for the author will be applied to the registry entry.
             did:gatc:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ethereum, Hyperledger Fabric, Hyperledger Besu, Alastria
           </td>
           <td>
@@ -2968,28 +2868,8 @@ contact information for the author will be applied to the registry entry.
           </td>
         </tr>
         <tr>
-          <td style="text-decoration:line-through">
-            did:git:
-          </td>
-          <td style="color:#FF0000">
-            WITHDRAWN
-          </td>
-          <td style="text-decoration:line-through">
-            DID Specification
-          </td>
-          <td style="text-decoration:line-through">
-            Internet Identity Workshop
-          </td>
-          <td style="text-decoration:line-through">
-            <a href="https://github.com/dhuseby/did-git-spec/blob/master/did-git-spec.md">Git DID Method</a>
-          </td>
-        </tr>
-        <tr>
           <td>
             did:grg:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             GrgChain
@@ -3006,9 +2886,6 @@ contact information for the author will be applied to the registry entry.
             did:hedera:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Hedera Hashgraph
           </td>
           <td>
@@ -3021,9 +2898,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:holo:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Holochain
@@ -3040,9 +2914,6 @@ contact information for the author will be applied to the registry entry.
             did:hpass:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Hyperledger Fabric
           </td>
           <td>
@@ -3055,9 +2926,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:icon:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             ICON
@@ -3074,9 +2942,6 @@ contact information for the author will be applied to the registry entry.
                 did:infra:
             </td>
             <td>
-                PROVISIONAL
-            </td>
-            <td>
                 <a href="https://infrablockchain.com">InfraBlockchain</a>
             </td>
             <td>
@@ -3089,9 +2954,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:io:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             IoTeX
@@ -3108,9 +2970,6 @@ contact information for the author will be applied to the registry entry.
             did:ion:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Bitcoin
           </td>
           <td>
@@ -3123,9 +2982,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:iota:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             IOTA
@@ -3142,9 +2998,6 @@ contact information for the author will be applied to the registry entry.
             did:ipid:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             IPFS
           </td>
           <td>
@@ -3157,9 +3010,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:is:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Blockcore
@@ -3176,9 +3026,6 @@ contact information for the author will be applied to the registry entry.
             did:iwt:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             InfoWallet
           </td>
           <td>
@@ -3191,9 +3038,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:jlinc:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             JLINC Protocol
@@ -3210,9 +3054,6 @@ contact information for the author will be applied to the registry entry.
             did:jnctn:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Jnctn Network
           </td>
           <td>
@@ -3225,9 +3066,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:jolo:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -3244,9 +3082,6 @@ contact information for the author will be applied to the registry entry.
             did:keri:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ledger agnostic
           </td>
           <td>
@@ -3259,9 +3094,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:key:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ledger independent DID method based on public/private key pairs
@@ -3278,9 +3110,6 @@ contact information for the author will be applied to the registry entry.
             did:kilt:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             KILT Blockchain
           </td>
           <td>
@@ -3293,9 +3122,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:klay:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Klaytn
@@ -3312,9 +3138,6 @@ contact information for the author will be applied to the registry entry.
             did:kr:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Korea Mobile Identity System
           </td>
           <td>
@@ -3327,9 +3150,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:lac:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             LACChain Network
@@ -3346,9 +3166,6 @@ contact information for the author will be applied to the registry entry.
             did:life:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             RChain
           </td>
           <td>
@@ -3361,9 +3178,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:lit:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             LEDGIS
@@ -3380,9 +3194,6 @@ contact information for the author will be applied to the registry entry.
             did:meme:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ledger agnostic
           </td>
           <td>
@@ -3395,9 +3206,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:meta:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Metadium
@@ -3414,9 +3222,6 @@ contact information for the author will be applied to the registry entry.
             did:moac:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             MOAC
           </td>
           <td>
@@ -3429,9 +3234,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:monid:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -3448,9 +3250,6 @@ contact information for the author will be applied to the registry entry.
             did:morpheus:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Hydra
           </td>
           <td>
@@ -3463,9 +3262,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:mydata:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             iGrant.io
@@ -3482,9 +3278,6 @@ contact information for the author will be applied to the registry entry.
             did:near:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             NEAR
           </td>
           <td>
@@ -3497,9 +3290,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:nft:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ceramic Network
@@ -3516,9 +3306,6 @@ contact information for the author will be applied to the registry entry.
             did:ockam:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ockam
           </td>
           <td>
@@ -3531,9 +3318,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:omn:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             OmniOne
@@ -3550,9 +3334,6 @@ contact information for the author will be applied to the registry entry.
             did:onion:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ledger agnostic
           </td>
           <td>
@@ -3565,9 +3346,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:ont:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ontology
@@ -3584,9 +3362,6 @@ contact information for the author will be applied to the registry entry.
             did:op:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ocean Protocol
           </td>
           <td>
@@ -3599,9 +3374,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:orb:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ledger agnostic
@@ -3618,9 +3390,6 @@ contact information for the author will be applied to the registry entry.
             did:panacea:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Panacea
           </td>
           <td>
@@ -3633,9 +3402,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:peer:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             peer
@@ -3652,9 +3418,6 @@ contact information for the author will be applied to the registry entry.
             did:pistis:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ethereum
           </td>
           <td>
@@ -3667,9 +3430,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:pkh:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ledger-independent generative DID method based on CAIP-10 keypair expressions
@@ -3686,9 +3446,6 @@ contact information for the author will be applied to the registry entry.
             did:pml:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             PML Chain
           </td>
           <td>
@@ -3701,9 +3458,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:polygon:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Polygon (Previously MATIC)
@@ -3720,9 +3474,6 @@ contact information for the author will be applied to the registry entry.
             did:ptn:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             PalletOne
           </td>
           <td>
@@ -3735,9 +3486,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:safe:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Gnosis Safe
@@ -3754,9 +3502,6 @@ contact information for the author will be applied to the registry entry.
             did:san:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             SAN Cloudchain
           </td>
           <td>
@@ -3769,9 +3514,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:schema:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Multiple storage networks, currently public IPFS and evan.network IPFS
@@ -3788,9 +3530,6 @@ contact information for the author will be applied to the registry entry.
             did:selfkey:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ethereum
           </td>
           <td>
@@ -3803,9 +3542,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:sideos:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ledger agnostic
@@ -3822,9 +3558,6 @@ contact information for the author will be applied to the registry entry.
             did:signor:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Ethereum, Hedera Hashgraph, Quorum, Hyperledger Besu
           </td>
           <td>
@@ -3837,9 +3570,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:sirius:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             ProximaX Sirius Chain
@@ -3856,9 +3586,6 @@ contact information for the author will be applied to the registry entry.
                 did:sol:
             </td>
             <td>
-                PROVISIONAL
-            </td>
-            <td>
                 Solana
             </td>
             <td>
@@ -3871,9 +3598,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:sov:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Sovrin
@@ -3890,9 +3614,6 @@ contact information for the author will be applied to the registry entry.
             did:ssb:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Secure Scuttlebutt
           </td>
           <td>
@@ -3905,9 +3626,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:ssw:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Initial Network
@@ -3924,9 +3642,6 @@ contact information for the author will be applied to the registry entry.
             did:stack:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Bitcoin
           </td>
           <td>
@@ -3941,9 +3656,6 @@ contact information for the author will be applied to the registry entry.
             did:tangle:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             IOTA Tangle
           </td>
           <td>
@@ -3956,9 +3668,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:tls:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -3976,9 +3685,6 @@ contact information for the author will be applied to the registry entry.
             did:trust:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             TrustChain
           </td>
           <td>
@@ -3991,9 +3697,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:trustbloc:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Hyperledger Fabric
@@ -4010,9 +3713,6 @@ contact information for the author will be applied to the registry entry.
             did:trx:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             TRON
           </td>
           <td>
@@ -4025,9 +3725,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:ttm:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             TMChain
@@ -4044,9 +3741,6 @@ contact information for the author will be applied to the registry entry.
             did:twit:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Twit
           </td>
           <td>
@@ -4059,9 +3753,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:tyron:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Zilliqa
@@ -4078,9 +3769,6 @@ contact information for the author will be applied to the registry entry.
             did:tys:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             DID Specification
           </td>
           <td>
@@ -4093,9 +3781,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:tz:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Tezos
@@ -4112,9 +3797,6 @@ contact information for the author will be applied to the registry entry.
             did:unik:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             <a href="https://docs.uns.network/">uns.network</a>
           </td>
           <td>
@@ -4127,9 +3809,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:unisot:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Bitcoin SV
@@ -4146,9 +3825,6 @@ contact information for the author will be applied to the registry entry.
             did:uns:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             <a href="https://docs.uns.network/">uns.network</a>
           </td>
           <td>
@@ -4160,26 +3836,7 @@ contact information for the author will be applied to the registry entry.
         </tr>
         <tr>
           <td>
-            did:uport:
-          </td>
-          <td>
-            DEPRECATED
-          </td>
-          <td>
-            Ethereum
-          </td>
-          <td>
-            uPort
-          </td>
-          <td>
-          </td>
-        </tr>
-        <tr>
-          <td>
             did:v1:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Veres One
@@ -4196,9 +3853,6 @@ contact information for the author will be applied to the registry entry.
             did:vaa:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             bif
           </td>
           <td>
@@ -4211,9 +3865,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:vaultie:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Ethereum
@@ -4230,9 +3881,6 @@ contact information for the author will be applied to the registry entry.
             did:vid:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             VP
           </td>
           <td>
@@ -4245,9 +3893,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:vivid:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             NEO2, NEO3, Zilliqa
@@ -4264,9 +3909,6 @@ contact information for the author will be applied to the registry entry.
             did:vvo:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Vivvo
           </td>
           <td>
@@ -4279,9 +3921,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:web:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Web
@@ -4298,9 +3937,6 @@ contact information for the author will be applied to the registry entry.
             did:wlk:
           </td>
           <td>
-            PROVISIONAL
-          </td>
-          <td>
             Weelink Network
           </td>
           <td>
@@ -4313,9 +3949,6 @@ contact information for the author will be applied to the registry entry.
         <tr>
           <td>
             did:work:
-          </td>
-          <td>
-            PROVISIONAL
           </td>
           <td>
             Hyperledger Fabric


### PR DESCRIPTION
In practice, we are making no value judgments about the quality of methods. The existence of the "PROVISIONAL" designation falsely makes it appear that we are.

If we recharter in such a way that making statements about DID methods becomes in scope, then we can resurrect a status column.  If we do this, I'd suggest using the categories "Required", "Recommended", "Optional", "Deprecated", and "Prohibited", which are used in the IANA JOSE Algorithms registry at https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms.