### PR TITLE
Update did:iota specification link

### DIFF
--- a/index.html
+++ b/index.html
@@ -3134,7 +3134,7 @@ contact information for the author will be applied to the registry entry.
             <a href="https://iota.org">IOTA Foundation</a>
           </td>
           <td>
-            <a href="https://github.com/iotaledger/identity.rs/blob/main/docs/specs/iota_did_method_spec.md">IOTA DID Method</a>
+            <a href="https://wiki.iota.org/identity.rs/specs/did/iota_did_method_spec">IOTA DID Method</a>
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
Updates the method specification link from the `did:iota` method to the appropriate page on their wiki. The old URL has become a dead link.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JelleMillenaar/did-spec-registries/pull/352.html" title="Last updated on Nov 1, 2021, 3:56 PM UTC (0dda847)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/352/29684c9...JelleMillenaar:0dda847.html" title="Last updated on Nov 1, 2021, 3:56 PM UTC (0dda847)">Diff</a>