### PR TITLE
Restore contact names for did:erc725

### DIFF
--- a/methods/erc725.json
+++ b/methods/erc725.json
@@ -2,7 +2,7 @@
   "name": "erc725",
   "status": "registered",
   "verifiableDataRegistry": "Ethereum",
-  "contactName": "Fabian Vogelsteller",
+  "contactName": "Markus Sabadello, Fabian Vogelsteller, Peter Kolarov",
   "contactEmail": "markus@danubetech.com",
   "contactWebsite": "",
   "specification": "https://github.com/WebOfTrustInfo/rebooting-the-web-of-trust-spring2018/blob/master/topics-and-advance-readings/DID-Method-erc725.md"


### PR DESCRIPTION
This method had 3 contact names, but only 1 was added in https://github.com/w3c/did-spec-registries/commit/6a3edacc20a424850656a66ad672983340b993ee.

Maybe one thing that got lost in https://github.com/w3c/did-spec-registries/pull/353 and https://github.com/w3c/did-spec-registries/pull/357 is the ability to have separate contact emails for multiple contacts. That could be good :)