### PR TITLE
Require that extension names are indicative of their function or nature

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,6 +202,12 @@ Any addition to the DID Core Registries MUST specify a human readable
 description of the addition.
       </li>
       <li>
+The name of the extension MUST be indicative of its function, or - in the case
+of DID Methods - of the nature of its underlying verifiable data registry or
+the company or community that proposes it. E.g. avoid properties such as
+"myProperty" or DID Methods such as "identity" or "registry".
+      </li>
+      <li>
 If there are copyright, trademark, or any intellectual property rights
 concerns, the addition and use MUST be authorized in writing by the intellectual
 property rights holder under a

--- a/index.html
+++ b/index.html
@@ -202,10 +202,10 @@ Any addition to the DID Core Registries MUST specify a human readable
 description of the addition.
       </li>
       <li>
-The name of the extension MUST be indicative of its function, or - in the case
-of DID Methods - of the nature of its underlying verifiable data registry or
-the company or community that proposes it. E.g. avoid properties such as
-"myProperty" or DID Methods such as "identity" or "registry".
+The name of each extension MUST be indicative of its function, or &mdash; as with
+DID Methods &mdash; of the nature of its underlying verifiable data registry and/or
+the company or community that proposes it. Avoid generic property names such as
+"myProperty" and DID Method names such as "identity" or "registry".
       </li>
       <li>
 If there are copyright, trademark, or any intellectual property rights


### PR DESCRIPTION
E.g. avoid properties such as "myProperty" or DID Methods such as "identity" or "registry".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/369.html" title="Last updated on Nov 17, 2021, 10:43 AM UTC (131b134)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/369/f8782b1...131b134.html" title="Last updated on Nov 17, 2021, 10:43 AM UTC (131b134)">Diff</a>