### PR TITLE
Restore contact names for did:erc725 (again)

### DIFF
--- a/methods/erc725.json
+++ b/methods/erc725.json
@@ -2,7 +2,7 @@
   "name": "erc725",
   "status": "registered",
   "verifiableDataRegistry": "Ethereum",
-  "contactName": "Fabian Vogelsteller",
+  "contactName": "Markus Sabadello, Fabian Vogelsteller, Peter Kolarov",
   "contactEmail": "markus@danubetech.com",
   "contactWebsite": "",
   "specification": "https://github.com/WebOfTrustInfo/rebooting-the-web-of-trust-spring2018/blob/master/topics-and-advance-readings/DID-Method-erc725.md"


### PR DESCRIPTION
Not sure why https://github.com/w3c/did-spec-registries/pull/368 was reverted in https://github.com/w3c/did-spec-registries/pull/371. Trying again.