### PR TITLE
Update auto-publish.yml

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -30,4 +30,4 @@ jobs:
           W3C_WG_DECISION_URL: https://www.w3.org/2019/did-wg/Meetings/Minutes/2020-06-09-did#resolution1
           W3C_BUILD_OVERRIDE: |
              shortName: did-spec-registries
-             specStatus: WG-NOTE
+             specStatus: NOTE


### PR DESCRIPTION
Changed the spec status identification to NOTE (post 2021 process change)
