### PR TITLE
Update to the correct location of the did:keri specification.

### DIFF
--- a/methods/keri.json
+++ b/methods/keri.json
@@ -3,7 +3,7 @@
   "status": "registered",
   "verifiableDataRegistry": "Ledger agnostic",
   "contactName": "Dr. Sam Smith, Charles Cunningham, Phil Feairheller",
-  "contactEmail": "",
+  "contactEmail": "pfeairheller@gmail.com",
   "contactWebsite": "",
-  "specification": "https://identity.foundation/keri/did_methods/"
+  "specification": "https://weboftrust.github.io/did-keri/"
 }


### PR DESCRIPTION
The did:keri specification has moved to a new repository located at https://github.com/weboftrust/did-keri/.  It is about to receive a major upgrade and we wanted to ensure that the link in the registry is correct.

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>
