### PR TITLE
Update contact information for Veres One DID Method.

### DIFF
--- a/methods/v1.json
+++ b/methods/v1.json
@@ -1,9 +1,9 @@
 {
   "name": "v1",
   "status": "registered",
-  "verifiableDataRegistry": "Veres One",
-  "contactName": "Digital Bazaar",
-  "contactEmail": "",
-  "contactWebsite": "https://digitalbazaar.com/",
+  "verifiableDataRegistry": "Veres One DLT",
+  "contactName": "Veres One Maintainer (Digital Bazaar)",
+  "contactEmail": "maintainer@veres.one",
+  "contactWebsite": "https://veres.one/",
   "specification": "https://w3c-ccg.github.io/did-method-v1/"
 }


### PR DESCRIPTION
We were asked to update the contact information for Veres One and list an email by @jandrieu in PR https://github.com/w3c/did-spec-registries/pull/395#issuecomment-1003212003. I thought we had already done this, but it seems we didn't. :)

This PR adds a contact email to Veres One and updates the website information.