### PR TITLE
Change publicKey -> verificationMethod

### DIFF
--- a/index.html
+++ b/index.html
@@ -601,7 +601,7 @@ verification relationship</a>.
         <pre class="example" title="Example of assertionMethod property">
 {
   ...
-  "publicKey": [{
+  "verificationMethod": [{
     "id": "did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q",
     "type": "EcdsaSecp256k1VerificationKey2019",
     "controller": "did:example:123",
@@ -650,7 +650,7 @@ verification relationship</a>.
         <pre class="example" title="Example of authentication property">
 {
   ...
-  "publicKey": [{
+  "verificationMethod": [{
     "id": "did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q",
     "type": "EcdsaSecp256k1VerificationKey2019",
     "controller": "did:example:123",
@@ -698,7 +698,7 @@ verification relationship</a>.
         <pre class="example" title="Example of capabilityDelegation property">
 {
   ...
-  "publicKey": [{
+  "verificationMethod": [{
     "id": "did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q",
     "type": "EcdsaSecp256k1VerificationKey2019",
     "controller": "did:example:123",
@@ -746,7 +746,7 @@ verification relationship</a>.
         <pre class="example" title="Example of capabilityInvocation property">
 {
   ...
-  "publicKey": [{
+  "verificationMethod": [{
     "id": "did:example:123#WjKgJV7VRw3hmgU6--4v15c0Aewbcvat1BsRFTIqa5Q",
     "type": "EcdsaSecp256k1VerificationKey2019",
     "controller": "did:example:123",
@@ -922,7 +922,7 @@ but is expected to not be used for newly defined suites.
       "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#"
     ],
     "id":"did:example:123",
-    "publicKey":[{
+    "verificationMethod":[{
       "id": "did:example:123#vm-2",
       "controller": "did:example:123",
       "type": "EcdsaSecp256k1RecoveryMethod2020",
@@ -981,7 +981,7 @@ but is expected to not be used for newly defined suites.
       "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#"
     ],
     "id":"did:example:123",
-    "publicKey":[{
+    "verificationMethod":[{
       "id": "did:example:123#vm-3",
       "controller": "did:example:123",
       "type": "EcdsaSecp256k1RecoveryMethod2020",
@@ -1025,7 +1025,7 @@ used for newly defined suites.
       "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#"
     ],
     "id":"did:example:123",
-    "publicKey":[{
+    "verificationMethod":[{
       "id": "did:example:123#vm-3",
       "controller": "did:example:123",
       "type": "EcdsaSecp256k1RecoveryMethod2020",
@@ -1302,7 +1302,7 @@ specification</a> for additional details on this topic.
     "https://gpg.jsld.org/contexts/lds-gpg2020-v0.0.jsonld"
   ],
   "id":"did:example:123",
-  "publicKey":[{
+  "verificationMethod":[{
     "id": "did:example:123#989ed1057a294c8a3665add842e784c4d08de1e2",
     "type": "PgpVerificationKey2021",
     "controller": "did:example:123",
@@ -1434,7 +1434,7 @@ the Security vocabulary JSON-LD context in the same document.
     "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020#"
   ],
   "id":"did:example:123",
-  "publicKey": [
+  "verificationMethod": [
     {
       "id": "did:example:123#vm-1",
       "controller": "did:example:123",


### PR DESCRIPTION
This changes "publicKey" to "verificationMethod" everywhere except in the section about "publicKey" itself, which is marked as deprecated.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/410.html" title="Last updated on Jan 24, 2022, 9:49 AM UTC (6771921)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/410/534bbd8...6771921.html" title="Last updated on Jan 24, 2022, 9:49 AM UTC (6771921)">Diff</a>