### PR TITLE
Add "internalError" error code.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1945,6 +1945,30 @@ These properties contain information pertaining to the DID resolution response.
         </pre>
       </section>
 
+      <section>
+        <h4>internalError</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/did-resolution/#internalerror">DID Resolution</a>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of internalError error value">
+{
+  "error": "internalError"
+}
+        </pre>
+      </section>
+
     </section>
   </section>
 


### PR DESCRIPTION
This adds a new error code for internal errors that can occur during DID Resolution or DID URL Dereferencing.

Errors are part of DID Resolution Metadata and DID URL Dereferencing Metadata.

@aljones15


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-spec-registries/pull/424.html" title="Last updated on Mar 14, 2022, 4:09 PM UTC (7c36936)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/424/c3f5009...peacekeeper:7c36936.html" title="Last updated on Mar 14, 2022, 4:09 PM UTC (7c36936)">Diff</a>