### PR TITLE
Add did:null method.

### DIFF
--- a/methods/null.json
+++ b/methods/null.json
@@ -1,0 +1,9 @@
+{
+  "name": "null",
+  "status": "registered",
+  "specification": "https://digitalbazaar.github.io/did-method-null-spec/",
+  "contactName": "Digital Bazaar, Inc.",
+  "contactEmail": "support@digitalbazaar.com",
+  "contactWebsite": "https://digitalbazaar.com/",
+  "verifiableDataRegistry": "None"
+}


### PR DESCRIPTION
### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [ ] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [ ] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].

### Highly Complex and Intricate Implementation

https://github.com/digitalbazaar/did-method-null

### Notes

- I've been sitting on this partially done spec and code since March 2020.  Wasn't feeling like posting amusing things back then.  Arguably this never was amusing.
- While this appears kind of nonsensical, it may have real use in testing.  Could be useful to bootstrap code with something this trivial. And maybe useful to check null/empty conditions in tests.  I started did-test-suite support for this but that got more involved than I expected.