### PR TITLE
Removing myself as code owner in this repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,6 +3,6 @@
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a 
 # pull request.
-*       @msporny @OR13 @mprorock @kdenhartog
+*       @msporny @OR13 @mprorock
 
 # See CODEOWNERS syntax here: https://help.github.com/articles/about-codeowners/#codeowners-syntax

--- a/index.html
+++ b/index.html
@@ -65,13 +65,14 @@ var respecConfig = {
     company: "mesur.io",
     companyURL: "https://mesur.io/",
     w3cid: 130636
-  }, {
+  }
+],
+  formerEditors: [{
     name: "Kyle Den Hartog",
     url: "https://www.linkedin.com/in/kyledenhartog/",
     company: "MATTR",
-    companyURL: "https://mattr.global/"
-  }
-],
+    companyURL: "https://mattr.global/",
+  }]
 
   // authors, add as many as you like.
   // This is optional, uncomment if you have authors as well as editors.


### PR DESCRIPTION
I'd been meaning to make this update awhile ago, but never got around to it. Due to me not working on DID/VC stuff as much in my day to day anymore I decided to give up my role as editor on a few specs. I'll still keep my eye on things as they go, but this is what I felt would be best so I'm not blocking this work. This is meant to complete that with the only thing left being for @iherman to demote my privileges on this repo I believe.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 15, 2022, 10:08 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fdid-spec-registries%2F7bdf24358dbb6a379718023268cf38e9f5325b2d%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/a3aWIR/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2022-06-15
ReSpec version: 32.1.8
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 28916ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:247:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/did-spec-registries%23438.)._
</details>
