### PR TITLE
Add  DID Dereferencing Metadata section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1875,30 +1875,6 @@ These properties contain information pertaining to the DID resolution response.
       </section>
 
       <section>
-        <h4>invalidDidUrl</h4>
-        <table class="simple" style="width: 100%;">
-          <thead>
-            <tr>
-              <th>Normative Definition</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <a href="https://www.w3.org/TR/did-core/#did-url-dereferencing-metadata">DID Core</a>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <pre class="example" title="Example of invalidDidUrl error value">
-{
-  "error": "invalidDidUrl"
-}
-        </pre>
-      </section>
-
-      <section>
         <h4>notFound</h4>
         <table class="simple" style="width: 100%;">
           <thead>

--- a/index.html
+++ b/index.html
@@ -1972,7 +1972,84 @@ These properties contain information pertaining to the DID resolution response.
 
     </section>
   </section>
+  <section>
+    <h3>DID Dereferencing Metadata</h3>
+    <p>
+These properties contain information pertaining to the DID dereferencing response.
+    </p>
+    <section>
+      <h3>error</h3>
+      <table class="simple" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>Normative Definition</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/did-core/#did-url-dereferencing-metadata">DID Core</a>
+            </td>
+            <td>
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
+      <pre class="example" title="Example of error metadata property">
+{
+  "error": "notFound"
+}
+      </pre>
+      <section>
+        <h4>invalidDidUrl</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://www.w3.org/TR/did-core/#did-url-dereferencing-metadata">DID Core</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of invalidDidUrl error value">
+{
+  "error": "invalidDidUrl"
+}
+        </pre>
+      </section>
+      <section>
+        <h4>notFound</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://www.w3.org/TR/did-core/#did-url-dereferencing-metadata">DID Core</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of notFound error value">
+{
+  "error": "notFound"
+}
+        </pre>
+      </section>
+    </section>
+  </section>
   <section>
     <h1>DID Document Metadata</h1>
     <p>


### PR DESCRIPTION
Purpose:

This PR adds a section for `DID Dereferencing Metadata` errors.
Not sure if needed, but noticed they were missing.

Image:
![20220727_12h44m47s_grim](https://user-images.githubusercontent.com/278280/181303751-4aa0007c-7cb0-4520-86d9-4228d2e494e2.png)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/did-spec-registries/pull/446.html" title="Last updated on Aug 1, 2022, 5:32 PM UTC (489cc62)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/446/8aea62a...aljones15:489cc62.html" title="Last updated on Aug 1, 2022, 5:32 PM UTC (489cc62)">Diff</a>