### PR TITLE
Add did key errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1969,8 +1969,99 @@ These properties contain information pertaining to the DID resolution response.
 }
         </pre>
       </section>
+      <section>
+        <h4>invalidPublicKeyLength</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/did-method-key/#signature-method-creation-algorithm">The did:key Method</a>
+            </td>
+          </tr>
+          </tbody>
+        </table>
 
-    </section>
+        <pre class="example" title="Example of invalidPublicKeyLength error value">
+{
+  "error": "invalidPublicKeyLength"
+}
+        </pre>
+      </section>
+      <section>
+        <h4>invalidPublicKey</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/did-method-key/#signature-method-creation-algorithm">The did:key Method</a>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of invalidPublicKey error value">
+{
+  "error": "invalidPublicKey"
+}
+        </pre>
+      </section>
+      <section>
+        <h4>unsupportedPublicKeyType</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/did-method-key/#signature-method-creation-algorithm">The did:key Method</a>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of unsupportedPublicKeyType error value">
+{
+  "error": "unsupportedPublicKeyType"
+}
+        </pre>
+      </section>
+      <section>
+        <h4>invalidPublicKeyType</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/did-method-key/#signature-method-creation-algorithm">The did:key Method</a>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of invalidPublicKeyType error value">
+{
+  "error": "invalidPublicKeyType"
+}
+        </pre>
+      </section>
+</section>
   </section>
 
   <section>

--- a/index.html
+++ b/index.html
@@ -1970,29 +1970,6 @@ These properties contain information pertaining to the DID resolution response.
         </pre>
       </section>
       <section>
-        <h4>invalidPublicKeyLength</h4>
-        <table class="simple" style="width: 100%;">
-          <thead>
-          <tr>
-            <th>Normative Definition</th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr>
-            <td>
-              <a href="https://w3c-ccg.github.io/did-resolution/#invalidPublicKeyLengthr">DID Resolution</a>
-            </td>
-          </tr>
-          </tbody>
-        </table>
-
-        <pre class="example" title="Example of invalidPublicKeyLength error value">
-{
-  "error": "invalidPublicKeyLength"
-}
-        </pre>
-      </section>
-      <section>
         <h4>invalidPublicKey</h4>
         <table class="simple" style="width: 100%;">
           <thead>
@@ -2016,7 +1993,7 @@ These properties contain information pertaining to the DID resolution response.
         </pre>
       </section>
       <section>
-        <h4>unsupportedPublicKeyType</h4>
+        <h4>invalidPublicKeyLength</h4>
         <table class="simple" style="width: 100%;">
           <thead>
           <tr>
@@ -2026,15 +2003,15 @@ These properties contain information pertaining to the DID resolution response.
           <tbody>
           <tr>
             <td>
-              <a href="https://w3c-ccg.github.io/did-resolution/#unsupportedPublicKeyType">DID Resolution</a>
+              <a href="https://w3c-ccg.github.io/did-resolution/#invalidPublicKeyLengthr">DID Resolution</a>
             </td>
           </tr>
           </tbody>
         </table>
 
-        <pre class="example" title="Example of unsupportedPublicKeyType error value">
+        <pre class="example" title="Example of invalidPublicKeyLength error value">
 {
-  "error": "unsupportedPublicKeyType"
+  "error": "invalidPublicKeyLength"
 }
         </pre>
       </section>
@@ -2058,6 +2035,30 @@ These properties contain information pertaining to the DID resolution response.
         <pre class="example" title="Example of invalidPublicKeyType error value">
 {
   "error": "invalidPublicKeyType"
+}
+        </pre>
+      </section>
+
+      <section>
+        <h4>unsupportedPublicKeyType</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/did-resolution/#unsupportedPublicKeyType">DID Resolution</a>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of unsupportedPublicKeyType error value">
+{
+  "error": "unsupportedPublicKeyType"
 }
         </pre>
       </section>

--- a/index.html
+++ b/index.html
@@ -1980,7 +1980,7 @@ These properties contain information pertaining to the DID resolution response.
           <tbody>
           <tr>
             <td>
-              <a href="https://w3c-ccg.github.io/did-method-key/#signature-method-creation-algorithm">The did:key Method</a>
+              <a href="https://w3c-ccg.github.io/did-resolution/#invalidPublicKeyLengthr">DID Resolution</a>
             </td>
           </tr>
           </tbody>
@@ -2003,7 +2003,7 @@ These properties contain information pertaining to the DID resolution response.
           <tbody>
           <tr>
             <td>
-              <a href="https://w3c-ccg.github.io/did-method-key/#signature-method-creation-algorithm">The did:key Method</a>
+              <a href="https://w3c-ccg.github.io/did-resolution/#invalidPublicKey">DID Resolution</a>
             </td>
           </tr>
           </tbody>
@@ -2026,7 +2026,7 @@ These properties contain information pertaining to the DID resolution response.
           <tbody>
           <tr>
             <td>
-              <a href="https://w3c-ccg.github.io/did-method-key/#signature-method-creation-algorithm">The did:key Method</a>
+              <a href="https://w3c-ccg.github.io/did-resolution/#unsupportedPublicKeyType">DID Resolution</a>
             </td>
           </tr>
           </tbody>
@@ -2049,7 +2049,7 @@ These properties contain information pertaining to the DID resolution response.
           <tbody>
           <tr>
             <td>
-              <a href="https://w3c-ccg.github.io/did-method-key/#signature-method-creation-algorithm">The did:key Method</a>
+              <a href="https://w3c-ccg.github.io/did-resolution/#invalidPublicKeyType">DID Resolution</a>
             </td>
           </tr>
           </tbody>


### PR DESCRIPTION
These errors await this PR on [did resolution](https://github.com/w3c-ccg/did-resolution/pull/71)

This PR adds errors from the [did method key spec](https://w3c-ccg.github.io/did-method-key/)

It adds entries for:

- invalidPublicKeyLength
- invalidPublicKey
- invalidDidUrl
- unsupportedPublicKeyType
- invalidPublicKeyType

Image:
![20220727_16h21m59s_grim](https://user-images.githubusercontent.com/278280/181365105-d0bbf574-8d93-4cca-a361-3683be448644.png)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/did-spec-registries/pull/447.html" title="Last updated on Jul 27, 2022, 8:33 PM UTC (b993af8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/447/8aea62a...aljones15:b993af8.html" title="Last updated on Jul 27, 2022, 8:33 PM UTC (b993af8)">Diff</a>