### PR TITLE
Add did:ev DID method

### DIFF
--- a/methods/ev.json
+++ b/methods/ev.json
@@ -1,0 +1,9 @@
+{
+  "name": "ev",
+  "status": "registered",
+  "specification": "https://github.com/KayTrust/did-method-ev",
+  "contactName": "David Ammouial (NTT DATA)",
+  "contactEmail": "<firstName>.<lastName>@nttdata.com",
+  "contactWebsite": "https://kaytrust.id/",
+  "verifiableDataRegistry": "Any Ethereum or EVM-compatible ledger"
+}

--- a/methods/ev.json
+++ b/methods/ev.json
@@ -3,7 +3,7 @@
   "status": "registered",
   "specification": "https://github.com/KayTrust/did-method-ev",
   "contactName": "David Ammouial (NTT DATA)",
-  "contactEmail": "<firstName>.<lastName>@nttdata.com",
+  "contactEmail": "david.ammouial@nttdata.com",
   "contactWebsite": "https://kaytrust.id/",
   "verifiableDataRegistry": "Any Ethereum or EVM-compatible ledger"
 }


### PR DESCRIPTION
I would like to submit DID method "ev" to the registry, please.

### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].
