### PR TITLE
Add zk DID Method

### DIFF
--- a/methods/zk.json
+++ b/methods/zk.json
@@ -1,0 +1,9 @@
+  {
+      "name": "zk",
+      "status": "registered",
+      "verifiableDataRegistry": "Arweave",
+      "contactName": "zCloak Network Research",
+      "contactEmail": "info@zcloak.network",
+      "contactWebsite": "https://zcloak.network/#/",
+      "specification": "https://github.com/zCloak-Network/zk-did-method-specs"
+  }


### PR DESCRIPTION
I would like to submit DID method "zk" to the registry, please.

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:
-  The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
-  The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
-  The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
-  The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
-  The JSON file I am submitting has [passed all automated validation tests below](https://github.com/w3c/did-spec-registries/pull/470#partial-pull-merging).
-  The JSON file contains a contactEmail address [OPTIONAL].
-  The JSON file contains a verifiableDataRegistry entry [OPTIONAL].