### PR TITLE
Add scid DID Method

### DIFF
--- a/methods/scid.json
+++ b/methods/scid.json
@@ -1,0 +1,9 @@
+{
+  "name": "scid",
+  "status": "registered",
+  "verifiableDataRegistry": "StraitsChain",
+  "contactName": "Lorna",
+  "contactEmail": "lornayang@straitschain.com",
+  "contactWebsite": "https://straitschain.com/",
+  "specification": "https://github.com/StraitsChain/SCID/blob/main/README.md"
+}


### PR DESCRIPTION
I would like to submit DID method "scid" to the registry, please.

DID Method Registration
As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

 The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
 The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
 The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
 The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
 The JSON file I am submitting has [passed all automated validation tests below](https://github.com/w3c/did-spec-registries/pull/470#partial-pull-merging).
 The JSON file contains a contactEmail address [OPTIONAL].
 The JSON file contains a verifiableDataRegistry entry [OPTIONAL].