### PR TITLE
fix invalid link

### DIFF
--- a/methods/nuts.json
+++ b/methods/nuts.json
@@ -4,6 +4,6 @@
   "verifiableDataRegistry": "Nuts network",
   "contactName": "Nuts community",
   "contactEmail": "w3c-did-core@nuts.nl",
-  "contactWebsite": "https://nuts-foundation.slack.com, https://nuts.nl",
+  "contactWebsite": "https://nuts.nl",
   "specification": "https://nuts-foundation.gitbook.io/drafts/rfc/rfc006-distributed-registry"
 }


### PR DESCRIPTION
This invalid link in `methods/nuts.json` made its way into `index.html`, which made it invalid HTML and also broke the automated publication process (#466).

More precisely, after generating `index.html.built.html` with ReSpec, the `specprod` action inspects the HTML file to build a list of all assets. This is the part where the broken link caused a fatal error.

I suggest that the task `registry:validate`  be improved to catch this kind of error in the future...