### PR TITLE
Add cr DID Method

### DIFF
--- a/methods/cr.json
+++ b/methods/cr.json
@@ -1,0 +1,9 @@
+{
+  "name": "cr",
+  "status": "registered",
+  "specification": "https://github.com/SelfSovereignDrm/core/blob/main/README.md",
+  "contactName": "",
+  "contactEmail": "ssdrm@digicaps.com",
+  "contactWebsite": "",
+  "verifiableDataRegistry": "Hyperledger Fabric"
+}


### PR DESCRIPTION
I would like to submit DID method "cr" to the registry, please.

###  DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].
