### PR TITLE
Add 'methodNotSupported' error.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1923,6 +1923,30 @@ These properties contain information pertaining to the DID resolution response.
       </section>
 
       <section>
+        <h4>methodNotSupported</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+          <tr>
+            <th>Normative Definition</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>
+              <a href="https://w3c-ccg.github.io/did-resolution/#methodnotsupported">DID Resolution</a>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of methodNotSupported error value">
+{
+  "error": "methodNotSupported"
+}
+        </pre>
+      </section>
+
+      <section>
         <h4>internalError</h4>
         <table class="simple" style="width: 100%;">
           <thead>


### PR DESCRIPTION
This is already used by some implementations, e.g. [Universal Resolver](https://github.com/decentralized-identity/universal-resolver) and [did-resolver](https://github.com/decentralized-identity/did-resolver/).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-spec-registries/pull/481.html" title="Last updated on Nov 28, 2022, 11:38 AM UTC (9da3625)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/481/eab3565...peacekeeper:9da3625.html" title="Last updated on Nov 28, 2022, 11:38 AM UTC (9da3625)">Diff</a>