### PR TITLE
Add did:ccf method

### DIFF
--- a/methods/ccf.json
+++ b/methods/ccf.json
@@ -1,7 +1,7 @@
 {
     "name": "ccf",
     "status": "registered",
-    "verifiableDataRegistry": "Ledger agnostic",
+    "verifiableDataRegistry": "CCF",
     "contactName": "Microsoft",
     "contactEmail": "bmurdoch@microsoft.com",
     "contactWebsite": "https://www.microsoft.com/en-us/research/project/confidential-consortium-framework/",

--- a/methods/ccf.json
+++ b/methods/ccf.json
@@ -1,0 +1,10 @@
+{
+    "name": "ccf",
+    "status": "registered",
+    "verifiableDataRegistry": "Ledger agnostic",
+    "contactName": "Microsoft",
+    "contactEmail": "bmurdoch@microsoft.com",
+    "contactWebsite": "https://www.microsoft.com/en-us/research/project/confidential-consortium-framework/",
+    "specification": "https://github.com/microsoft/did-ccf/blob/main/DID_CCF.md"
+  }
+  


### PR DESCRIPTION
DID Method Registration
As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

 The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
 The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
 The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
 The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
 The JSON file I am submitting has [passed all automated validation tests below](https://github.com/w3c/did-spec-registries/pull/483#partial-pull-merging).
 The JSON file contains a contactEmail address [OPTIONAL].
 The JSON file contains a verifiableDataRegistry entry [OPTIONAL].