### PR TITLE
Add WotThing and WotDirectory service types

### DIFF
--- a/index.html
+++ b/index.html
@@ -1667,8 +1667,9 @@ in a service object.
           This can be used for self-describing devices or services, or be a service
           separate from the actual device or service described by the TD.
           The <code>WotDirectory</code> is also a REST service that returns a TD, but this service is always
-          a Web of Things (WoT) Thing Description Directory (TDD), and the TD returned by a <code>GET</code> always describes the TDD's interface.
-          Details (including normative statements detailing the above) are in the
+          a Web of Things (WoT) Thing Description Directory (TDD),
+          and the TD returned by a <code>GET</code> always describes the TDD's interface.
+          Details (including normative statements covering the above) are in the
           <a href="https://www.w3.org/TR/wot-discovery/">WoT Discovery</a> specification.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -1821,7 +1821,6 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
             </tr>
           </tbody>
         </table>
-        
         <pre class="example" title="Example of service and serviceEndpoint properties">
 {
   ...

--- a/index.html
+++ b/index.html
@@ -1668,12 +1668,12 @@ in a service object.
         <h4>Web of Things (WoT) Discovery</h4>
         <p>The <code>WotThing</code> and <code>WotDirectory</code> endpoints allow publication of service endpoints in a DID document
           that can be used to fetch Web of Things (WoT) Thing Descriptions (TDs).
-          In the case of <code>WotThing</code>, the endpoint is a REST service that returns a TD
-          when the GET method is used.  
-          This can be used by either self-describing devices or services but can also be a service
+          The <code>WotThing</code> endpoint is a REST service that returns a TD
+          when the <code>GET</code> method is used.  
+          This can be used for self-describing devices or services or be a service
           separate from the actual device or service described by the TD.
-          The case of <code>WotDirectory</code> is also a REST service that returns a TD but this service is always
-          a Web of Things (WoT) Thing Description Directory (TDD) and the TD returned by a GET always describes the TDD's interface.
+          The <code>WotDirectory</code> is also a REST service that returns a TD, but this service is always
+          a Web of Things (WoT) Thing Description Directory (TDD), and the TD returned by a <code>GET</code> always describes the TDD's interface.
           Details (including normative statements detailing the above) are in the
           <a href="https://www.w3.org/TR/wot-discovery/">WoT Discovery</a> specification.
         </p>

--- a/index.html
+++ b/index.html
@@ -1629,6 +1629,72 @@ in a service object.
 
       </section>
 
+      <section id="wot-discovery-service-type">
+        <h4>Web of Things (WoT) Discovery</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON-LD</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://www.w3.org/TR/wot-discovery/">WoT Discovery</a>
+              </td>
+              <td>
+                <span class="issue">A valid JSON-LD context needs to be published.</span>
+                <a href="https://www.w3.org/2021/wot/discovery/did#WotThing">WotThing</a>
+              </td>
+            </tr><tr>
+              <td>
+                <a href="https://www.w3.org/TR/wot-discovery/">WoT Discovery</a>
+              </td>
+              <td>
+                <span class="issue">A valid JSON-LD context needs to be published.</span>
+                <a href="https://www.w3.org/2021/wot/discovery/did#WotDirectory">WotDirectory</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of WotThing serviceEndpoint properties">
+{
+  "@context":[
+      "https://www.w3.org/ns/did/v1",
+      "https://www.w3.org/2021/wot/discovery/did"
+  ],
+  ...
+  "service": [{
+      "id": "did:example:wotdiscoveryexample#td",
+      "type": "WotThing",
+      "serviceEndpoint":
+          "https://wot.example.com/.well-known/wot"
+  }]
+  ...
+}
+        </pre>
+
+        <pre class="example" title="Example of WotDirectory serviceEndpoint properties">
+{
+  "@context":[
+      "https://www.w3.org/ns/did/v1",
+      "https://www.w3.org/2021/wot/discovery/did"
+  ],
+  ...
+  "service": [{
+      "id": "did:example:wotdiscoveryexample#tdd",
+      "type": "WotDirectory",
+      "serviceEndpoint":
+          "https://wot.example.com/tdd"
+  }]
+  ...
+}
+        </pre>
+
+      </section>
+
     </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -1645,7 +1645,7 @@ in a service object.
               </td>
               <td>
                 <span class="issue">A valid JSON-LD context needs to be published.</span>
-                <a href="https://www.w3.org/2022/wot/discovery/did#WotThing">WotThing</a>
+                <a href="https://www.w3.org/2022/wot/discovery-did#WotThing">WotThing</a>
               </td>
             </tr><tr>
               <td>
@@ -1653,7 +1653,7 @@ in a service object.
               </td>
               <td>
                 <span class="issue">A valid JSON-LD context needs to be published.</span>
-                <a href="https://www.w3.org/2022/wot/discovery/did#WotDirectory">WotDirectory</a>
+                <a href="https://www.w3.org/2022/wot/discovery-did#WotDirectory">WotDirectory</a>
               </td>
             </tr>
           </tbody>
@@ -1663,7 +1663,7 @@ in a service object.
 {
   "@context":[
       "https://www.w3.org/ns/did/v1",
-      "https://www.w3.org/2022/wot/discovery/did"
+      "https://www.w3.org/2022/wot/discovery-did"
   ],
   ...
   "service": [{
@@ -1680,7 +1680,7 @@ in a service object.
 {
   "@context":[
       "https://www.w3.org/ns/did/v1",
-      "https://www.w3.org/2022/wot/discovery/did"
+      "https://www.w3.org/2022/wot/discovery-did"
   ],
   ...
   "service": [{

--- a/index.html
+++ b/index.html
@@ -1670,7 +1670,7 @@ in a service object.
           that can be used to fetch Web of Things (WoT) Thing Descriptions (TDs).
           The <code>WotThing</code> endpoint is a REST service that returns a TD
           when the <code>GET</code> method is used.  
-          This can be used for self-describing devices or services or be a service
+          This can be used for self-describing devices or services, or be a service
           separate from the actual device or service described by the TD.
           The <code>WotDirectory</code> is also a REST service that returns a TD, but this service is always
           a Web of Things (WoT) Thing Description Directory (TDD), and the TD returned by a <code>GET</code> always describes the TDD's interface.

--- a/index.html
+++ b/index.html
@@ -1645,7 +1645,7 @@ in a service object.
               </td>
               <td>
                 <span class="issue">A valid JSON-LD context needs to be published.</span>
-                <a href="https://www.w3.org/2021/wot/discovery/did#WotThing">WotThing</a>
+                <a href="https://www.w3.org/2022/wot/discovery/did#WotThing">WotThing</a>
               </td>
             </tr><tr>
               <td>
@@ -1653,7 +1653,7 @@ in a service object.
               </td>
               <td>
                 <span class="issue">A valid JSON-LD context needs to be published.</span>
-                <a href="https://www.w3.org/2021/wot/discovery/did#WotDirectory">WotDirectory</a>
+                <a href="https://www.w3.org/2022/wot/discovery/did#WotDirectory">WotDirectory</a>
               </td>
             </tr>
           </tbody>
@@ -1663,7 +1663,7 @@ in a service object.
 {
   "@context":[
       "https://www.w3.org/ns/did/v1",
-      "https://www.w3.org/2021/wot/discovery/did"
+      "https://www.w3.org/2022/wot/discovery/did"
   ],
   ...
   "service": [{
@@ -1680,7 +1680,7 @@ in a service object.
 {
   "@context":[
       "https://www.w3.org/ns/did/v1",
-      "https://www.w3.org/2021/wot/discovery/did"
+      "https://www.w3.org/2022/wot/discovery/did"
   ],
   ...
   "service": [{


### PR DESCRIPTION
This PR is registering the WotThing and WotDirectory service types to be used by Web of Things (WoT) Discovery.  The specification for WoT Discovery is being developed by the W3C Web of Things WG and is just entering CR: 
* [Current published version](https://www.w3.org/TR/wot-discovery/)
* [Editor's draft](https://w3c.github.io/wot-discovery/)

There is a proposed URL for a JSON-LD context file but the context file has not yet been published.  We are proposing using a special context file for this purpose rather than adding these definitions to an existing context file to keep it short, hence the "did" suffix on the URL.  The specs above do not include this context file and it will have to be added (since we are going to be in CR we are going to have to ask for permission...).

[Linked issue in WoT Discovery repo: 402](https://github.com/w3c/wot-discovery/issues/402)
Contact: Michael McCool (@mmccool)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/did-spec-registries/pull/486.html" title="Last updated on Jul 20, 2024, 9:39 PM UTC (a484257)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/486/c7b2b71...mmccool:a484257.html" title="Last updated on Jul 20, 2024, 9:39 PM UTC (a484257)">Diff</a>