### PR TITLE
Propose credential registry service

### DIFF
--- a/index.html
+++ b/index.html
@@ -1631,7 +1631,7 @@ in a service object.
 
       <section>
         <h4>CredentialRegistry</h4>
-        <p>A dedicated service endpoint for a DID to publish its credentials. A credential registry is a service endpoint which allows queries about verifiable credentials based on a <code>credentialSubject.id</code>, and returns an array of verifiable credentials associated with the subject. A sample registry endpoint can be found <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">here</a>.</p>
+        <p>The CredentialRegistry endpoint allows to publish a dedicated service endpoint in a did document from which verifiable credentials can be queried. Each registry endpoint is a REST endpoint. By appending the <code>credentialSubject.id</code> as an URL encoded string to the given endpoint and sending a GET request to that URI, the registry MUST return an array of verifiable credentials associated with the subject id. A sample registry endpoint can be found <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">here</a>.</p>
         <p class="note">
           Verifiable credential registries are supposed to hold credentials that are publicly accessible by default, e.g., for product passports on a product type level. An additional authentication for limiting access to certain credentials is currently under development.
         </p>
@@ -1668,7 +1668,7 @@ in a service object.
     {
       "id": "did:example:123#vcregistry-2",
       "type": "CredentialRegistry",
-      "serviceEndpoint": "https://vcregistry.example.com"
+      "serviceEndpoint": "https://ssi.eecc.de/api/registry/vcs/"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -1631,7 +1631,7 @@ in a service object.
 
       <section>
         <h4>CredentialRegistry</h4>
-        <p>The CredentialRegistry endpoint allows to publish a dedicated service endpoint in a did document from which verifiable credentials can be queried. Each registry endpoint is a REST endpoint. By appending the <code>credentialSubject.id</code> as an URL encoded string to the given endpoint and sending a GET request to that URI, the registry MUST return an array of verifiable credentials associated with the subject id. A sample registry endpoint can be found <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">here</a>.</p>
+        <p>The CredentialRegistry endpoint allows publication of a dedicated service endpoint in a DID document through which verifiable credentials can be queried. Each registry endpoint is a REST endpoint. When a GET request is sent to the URI formed by appending the <code>credentialSubject.id</code> as a URL-encoded string to the given endpoint URI, the registry MUST return an array of verifiable credentials associated with the subject ID. A sample registry endpoint can be found <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">here</a>.</p>
         <p class="note">
           Verifiable credential registries are supposed to hold credentials that are publicly accessible by default, e.g., for product passports on a product type level. An additional authentication for limiting access to certain credentials is currently under development.
         </p>

--- a/index.html
+++ b/index.html
@@ -1633,7 +1633,7 @@ in a service object.
         <h4>CredentialRegistry</h4>
         <p>A dedicated service endpoint for a DID to publish its credentials. A credential registry is a service endpoint which allows queries about verifiable credentials based on a <code>credentialSubject.id</code>, and returns an array of verifiable credentials associated with the subject. A sample registry endpoint can be found <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">here</a>.</p>
         <p class="note">
-          Verifiable credential registries are supposed to hold credentials that are publicly accessible by default, e.g. for product passports on a product type level. An additional authentication for limiting the access to certain credentials is currently under development.
+          Verifiable credential registries are supposed to hold credentials that are publicly accessible by default, e.g., for product passports on a product type level. An additional authentication for limiting access to certain credentials is currently under development.
         </p>
         <table class="simple" style="width: 100%;">
           <thead>

--- a/index.html
+++ b/index.html
@@ -1629,6 +1629,49 @@ in a service object.
 
       </section>
 
+      <section>
+        <h4>CredentialRegistry</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON-LD</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">Verifiable Credential Registry</a>
+              </td>
+              <td>
+                <a href="https://ssi.eecc.de/api/registry/context/credentialregistry">Verifiable Credential Registry</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of service and serviceEndpoint properties">
+{
+  ...
+  "service": [
+    {
+      "id": "did:example:123#vcregistry-1",
+      "type": "CredentialRegistry",
+      "serviceEndpoint": {
+        "registries": ["https://registry.example.com", "https://identity.foundation/vcs"]
+      }
+    },
+    {
+      "id": "did:example:123#vcregistry-2",
+      "type": "CredentialRegistry",
+      "serviceEndpoint": "https://vcregistry.example.com"
+    }
+  ]
+}
+        </pre>
+
+      </section>
+
     </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -1673,7 +1673,20 @@ in a service object.
   ]
 }
         </pre>
+        <pre class="example" title="Example of a concrete call to the specified serviceEndpoint and example answer">
+$ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H 'accept: application/ld+json, application/json'
 
+[
+  {
+    "@context": ["https://www.w3.org/2018/credentials/v1",... ],
+    "type": ["VerifiableCredential",...],
+    "credentialSubject": {...},
+    "proof": {...},
+    ...
+  },
+  ...
+]
+        </pre>
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1631,6 +1631,10 @@ in a service object.
 
       <section>
         <h4>CredentialRegistry</h4>
+        <p>A dedicated service endpoint for a DID for publishing its credentials. A credential registry is a service endpoint which allows to query verifiable credentials based on a <code>credentialSubject.id</code> and returns an array of verifiable credentials associated with the subject. A sample registry endpoint can be found <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">here</a>.</p>
+        <p class="note">
+          Verifiable credential registries are supposed to hold credentials that are publicly accessible by default, e.g. for product passports on a product type level. An additional authentication for limiting the access to certain credentials is currently under development.
+        </p>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>

--- a/index.html
+++ b/index.html
@@ -1631,7 +1631,7 @@ in a service object.
 
       <section>
         <h4>CredentialRegistry</h4>
-        <p>A dedicated service endpoint for a DID for publishing its credentials. A credential registry is a service endpoint which allows to query verifiable credentials based on a <code>credentialSubject.id</code> and returns an array of verifiable credentials associated with the subject. A sample registry endpoint can be found <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">here</a>.</p>
+        <p>A dedicated service endpoint for a DID to publish its credentials. A credential registry is a service endpoint which allows queries about verifiable credentials based on a <code>credentialSubject.id</code>, and returns an array of verifiable credentials associated with the subject. A sample registry endpoint can be found <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">here</a>.</p>
         <p class="note">
           Verifiable credential registries are supposed to hold credentials that are publicly accessible by default, e.g. for product passports on a product type level. An additional authentication for limiting the access to certain credentials is currently under development.
         </p>

--- a/index.html
+++ b/index.html
@@ -1662,7 +1662,7 @@ in a service object.
       "id": "did:example:123#vcregistry-1",
       "type": "CredentialRegistry",
       "serviceEndpoint": {
-        "registries": ["https://registry.example.com", "https://identity.foundation/vcs"]
+        "registries": ["https://registry.example.com/{credentialSubject.id}", "https://identity.foundation/vcs/{credentialSubject.id}"]
       }
     },
     {

--- a/index.html
+++ b/index.html
@@ -1668,7 +1668,7 @@ in a service object.
     {
       "id": "did:example:123#vcregistry-2",
       "type": "CredentialRegistry",
-      "serviceEndpoint": "https://ssi.eecc.de/api/registry/vcs/"
+      "serviceEndpoint": "https://ssi.eecc.de/api/registry/vcs/{credentialSubject.id}"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -1631,7 +1631,7 @@ in a service object.
 
       <section>
         <h4>CredentialRegistry</h4>
-        <p>The CredentialRegistry endpoint allows publication of a dedicated service endpoint in a DID document through which verifiable credentials can be queried. Each registry endpoint is a REST endpoint. When a GET request is sent to the URI formed by appending the <code>credentialSubject.id</code> as a URL-encoded string to the given endpoint URI, the registry MUST return an array of verifiable credentials associated with the subject ID. A sample registry endpoint can be found <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">here</a>.</p>
+        <p>The <code>CredentialRegistry</code> endpoint allows publication of a dedicated service endpoint in a DID document, through which verifiable credentials can be queried. Each registry endpoint is a REST endpoint. When a `GET` request is sent to the URI formed by appending the <code>credentialSubject.id</code> as a URL-encoded string to the given endpoint URI, the registry MUST return an array of verifiable credentials associated with the subject ID. A sample registry endpoint can be found <a href="https://ssi.eecc.de/api/registry/swagger/#/Credentials/get_api_registry_vcs__id_">here</a>.</p>
         <p class="note">
           Verifiable credential registries are supposed to hold credentials that are publicly accessible by default, e.g., for product passports on a product type level. An additional authentication for limiting access to certain credentials is currently under development.
         </p>


### PR DESCRIPTION
## CredentialRegistry service type

For promoting a verifiable credential registry used by a DID, a service endpoint can be published via a service in the DID document. Therefore we propose a dedicated service endpoint type `CredentialRegistry`.

The purpose is to be able to retrieve credentials by subject id, e.g. in order to collect credentials for a product passport like in this use case https://github.com/european-epc-competence-center/vc-verifier , in case the credentials shall be retrievable.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/european-epc-competence-center/did-spec-registries/pull/490.html" title="Last updated on Feb 1, 2023, 6:44 PM UTC (462b537)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/490/d81e09c...european-epc-competence-center:462b537.html" title="Last updated on Feb 1, 2023, 6:44 PM UTC (462b537)">Diff</a>