### PR TITLE
add OpenID4VC service types

### DIFF
--- a/index.html
+++ b/index.html
@@ -1763,8 +1763,8 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
 
       <section>
         <h4>OpenID4 Verifiable Presentation</h4>
-        <p>The <code>OID4VP</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenID for Verifiable Presentation (OID4VP)</a> authorization endpoint, which is the entry point for the <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html">presentation flow</a>.</p>
-        <p>The service endpoint `id` MUST be the authorization request endpoint as described in section <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-authorization-request">Authorization Request</a>.</p>
+        <p>The <code>OID4VP</code> service allows publication of how to interact with a credential wallet that conforms with the <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html">OpenID for Verifiable Presentation (OID4VP)</a> specification.</p>
+        <p>The service endpoint `id` MUST be the Wallet (OAuth2) Issuer Identifier to obtain Wallet Metadata to invoke the wallet as described in section <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-wallet-invocation">Wallet Invocation</a>.</p>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>

--- a/index.html
+++ b/index.html
@@ -1725,7 +1725,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
       </section>
 
       <section>
-        <h4>OpenID4VC Issuance</h4>
+        <h4>OpenID4 Verifiable Credential Issuance</h4>
         <p>The <code>OID4VCI</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenID for Verifiable Credential Issuance (OID4VCI)</a> domain, where the <code>.well-known</code> files (<code>oauth-authorization-server</code> & <code>openid-credential-issuer</code>) can be found. These files MUST contain the endpoints and meta data for <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID for Verifiable Credential Issuance (OpenID4VCI)</a>.</p>
         <table class="simple" style="width: 100%;">
           <thead>
@@ -1754,6 +1754,42 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
       "id": "did:example:123#oid4vci",
       "type": "OID4VCI",
       "serviceEndpoint": "https://did.example.com/"
+    }
+  ]
+}
+        </pre>
+      </section>
+
+      <section>
+        <h4>OpenID4 Verifiable Presentation</h4>
+        <p>The <code>OID4VP</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenID for Verifiable Presentation (OID4VP)</a> authorization endpoint, which is the entry point for the <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html">presentation flow</a>.</p>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON-LD</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-authorization-request">OpenID4VP</a>
+              </td>
+              <td>
+                -
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of service and serviceEndpoint properties">
+{
+  ...
+  "service": [
+    {
+      "id": "did:example:123#oid4vp",
+      "type": "OID4VP",
+      "serviceEndpoint": "https://did.example.com/authorize"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -1727,6 +1727,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
       <section>
         <h4>OpenID4 Verifiable Credential Issuance</h4>
         <p>The <code>OID4VCI</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenID for Verifiable Credential Issuance (OID4VCI)</a> domain, where the <code>.well-known</code> files (<code>oauth-authorization-server</code> & <code>openid-credential-issuer</code>) can be found. These files MUST contain the endpoints and meta data for <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID for Verifiable Credential Issuance (OpenID4VCI)</a>.</p>
+        <p>The service endpoint `id` MUST be the Credential Issuer Identifier to get the Credential Issuer Metadata as described in Section <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#credential-issuer-metadata">Credential Issuer Metadata</a> of <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenIDVCI</a>.</p>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1763,6 +1764,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
       <section>
         <h4>OpenID4 Verifiable Presentation</h4>
         <p>The <code>OID4VP</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenID for Verifiable Presentation (OID4VP)</a> authorization endpoint, which is the entry point for the <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html">presentation flow</a>.</p>
+        <p>The service endpoint `id` MUST be the authorization request endpoint as described in section <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-authorization-request">Authorization Request</a>.</p>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>

--- a/index.html
+++ b/index.html
@@ -1754,7 +1754,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
     {
       "id": "did:example:123#oid4vci",
       "type": "OID4VCI",
-      "serviceEndpoint": "https://did.example.com/"
+      "serviceEndpoint": "https://issuer.example.com/"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -1724,6 +1724,55 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
         </pre>
       </section>
 
+      <section>
+        <h4>OpenID4VC</h4>
+        <p>The <code>OpenID4VC</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenId for verifiable credentials (OpenID4VC)</a> <code>.well-known</code> locations where the endpoints and meta data for both <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenId for verifiable credential issuance (OpenID4VCI)</a> and <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html">OpenId for verifiable presentation (OpenID4VP)</a> can be found.</p>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON-LD</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID4VCI</a>
+                <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html">OpenID4VP</a>
+              </td>
+              <td>
+                <a href="https://ssi.eecc.de/api/registry/context/openid4vc">OpenID4VP</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of service and serviceEndpoint properties">
+{
+  ...
+  "service": [
+    {
+      "@context":[
+        "https://www.w3.org/ns/did/v1",
+        "https://ssi.eecc.de/api/registry/context/openid4vc"
+      ],
+      "id": "did:example:123#openid4vc-1",
+      "type": "OpenID4VC",
+      "serviceEndpoint": {
+        "oauth-authorization-server": "https://did.example.com/.well-known/oauth-authorization-server",
+        "openid-credential-issuer": "https://did.example.com/.well-known/openid-credential-issuer",
+      }
+    },
+    {
+      "id": "did:example:123#openid4vc-2",
+      "type": "OpenID4VC",
+      "serviceEndpoint": "https://did.example.com/"
+    }
+  ]
+}
+        </pre>
+      </section>
+
     </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -1791,7 +1791,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
     {
       "id": "did:example:123#oid4vp",
       "type": "OID4VP",
-      "serviceEndpoint": "https://did.example.com/authorize"
+      "serviceEndpoint": "https://wallet.example.com"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -1726,7 +1726,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
 
       <section>
         <h4>OpenID4VC</h4>
-        <p>The <code>OpenID4VC</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenId for verifiable credentials (OpenID4VC)</a> <code>.well-known</code> locations where the endpoints and meta data for both <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenId for verifiable credential issuance (OpenID4VCI)</a> and <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html">OpenId for verifiable presentation (OpenID4VP)</a> can be found.</p>
+        <p>The <code>OpenID4VC</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenID for Verifiable Credentials (OpenID4VC)</a> <code>.well-known</code> locations where the endpoints and meta data for both <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID for Verifiable Credential issuance (OpenID4VCI)</a> and <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html">OpenID for Verifiable Presentation (OpenID4VP)</a> can be found.</p>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>

--- a/index.html
+++ b/index.html
@@ -1740,7 +1740,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
                 <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID4VCI</a>
               </td>
               <td>
-                -
+                <a href="https://ssi.eecc.de/api/registry/context/openid4vc">OpenID4VCI</a>
               </td>
             </tr>
           </tbody>
@@ -1776,7 +1776,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
                 <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-authorization-request">OpenID4VP</a>
               </td>
               <td>
-                -
+                <a href="https://ssi.eecc.de/api/registry/context/openid4vc">OpenID4VP</a>
               </td>
             </tr>
           </tbody>

--- a/index.html
+++ b/index.html
@@ -1726,7 +1726,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
 
       <section>
         <h4>OpenID4VC Issuance</h4>
-        <p>The <code>OID4VCI</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenID for Verifiable Credential Issuance (OID4VCI)</a> <code>.well-known</code> locations where the endpoints and meta data for <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID for Verifiable Credential Issuance (OpenID4VCI)</a> can be found.</p>
+        <p>The <code>OID4VCI</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenID for Verifiable Credential Issuance (OID4VCI)</a> domain, where the <code>.well-known</code> files (<code>oauth-authorization-server</code> & <code>openid-credential-issuer</code>) can be found. These files MUST contain the endpoints and meta data for <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID for Verifiable Credential Issuance (OpenID4VCI)</a>.</p>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1740,7 +1740,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
                 <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID4VCI</a>
               </td>
               <td>
-                <a href="https://ssi.eecc.de/api/registry/context/openid4vc">OpenID4VP</a>
+                -
               </td>
             </tr>
           </tbody>
@@ -1751,19 +1751,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
   ...
   "service": [
     {
-      "@context":[
-        "https://www.w3.org/ns/did/v1",
-        "https://ssi.eecc.de/api/registry/context/openid4vc"
-      ],
-      "id": "did:example:123#oid4vci-1",
-      "type": "OID4VCI",
-      "serviceEndpoint": {
-        "oauth-authorization-server": "https://did.example.com/.well-known/oauth-authorization-server",
-        "openid-credential-issuer": "https://did.example.com/.well-known/openid-credential-issuer",
-      }
-    },
-    {
-      "id": "did:example:123#oid4vci-2",
+      "id": "did:example:123#oid4vci",
       "type": "OID4VCI",
       "serviceEndpoint": "https://did.example.com/"
     }

--- a/index.html
+++ b/index.html
@@ -1726,7 +1726,7 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
 
       <section>
         <h4>OpenID4 Verifiable Credential Issuance</h4>
-        <p>The <code>OID4VCI</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenID for Verifiable Credential Issuance (OID4VCI)</a> domain, where the <code>.well-known</code> files (<code>oauth-authorization-server</code> & <code>openid-credential-issuer</code>) can be found. These files MUST contain the endpoints and meta data for <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID for Verifiable Credential Issuance (OpenID4VCI)</a>.</p>
+        <p>The <code>OID4VCI</code> service allows publication of a credential issuer that conforms to the <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID for Verifiable Credential Issuance (OID4VCI)</a> specification.
         <p>The service endpoint `id` MUST be the Credential Issuer Identifier to get the Credential Issuer Metadata as described in Section <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#credential-issuer-metadata">Credential Issuer Metadata</a> of <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenIDVCI</a>.</p>
         <table class="simple" style="width: 100%;">
           <thead>

--- a/index.html
+++ b/index.html
@@ -1725,8 +1725,8 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
       </section>
 
       <section>
-        <h4>OpenID4VC</h4>
-        <p>The <code>OpenID4VC</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenID for Verifiable Credentials (OpenID4VC)</a> <code>.well-known</code> locations where the endpoints and meta data for both <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID for Verifiable Credential issuance (OpenID4VCI)</a> and <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html">OpenID for Verifiable Presentation (OpenID4VP)</a> can be found.</p>
+        <h4>OpenID4VC Issuance</h4>
+        <p>The <code>OID4VCI</code> service allows publication of the <a href="https://openid.net/openid4vc/">OpenID for Verifiable Credential Issuance (OID4VCI)</a> <code>.well-known</code> locations where the endpoints and meta data for <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID for Verifiable Credential Issuance (OpenID4VCI)</a> can be found.</p>
         <table class="simple" style="width: 100%;">
           <thead>
             <tr>
@@ -1738,7 +1738,6 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
             <tr>
               <td>
                 <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html">OpenID4VCI</a>
-                <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html">OpenID4VP</a>
               </td>
               <td>
                 <a href="https://ssi.eecc.de/api/registry/context/openid4vc">OpenID4VP</a>
@@ -1756,16 +1755,16 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
         "https://www.w3.org/ns/did/v1",
         "https://ssi.eecc.de/api/registry/context/openid4vc"
       ],
-      "id": "did:example:123#openid4vc-1",
-      "type": "OpenID4VC",
+      "id": "did:example:123#oid4vci-1",
+      "type": "OID4VCI",
       "serviceEndpoint": {
         "oauth-authorization-server": "https://did.example.com/.well-known/oauth-authorization-server",
         "openid-credential-issuer": "https://did.example.com/.well-known/openid-credential-issuer",
       }
     },
     {
-      "id": "did:example:123#openid4vc-2",
-      "type": "OpenID4VC",
+      "id": "did:example:123#oid4vci-2",
+      "type": "OID4VCI",
       "serviceEndpoint": "https://did.example.com/"
     }
   ]


### PR DESCRIPTION
## OpenID4VC

Added the [OpenId for verifiable credentials](https://openid.net/openid4vc/) discoverable endpoints as a service type.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/european-epc-competence-center/did-spec-registries/pull/513.html" title="Last updated on Jun 27, 2023, 8:08 AM UTC (bb07e2f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/513/4897706...european-epc-competence-center:bb07e2f.html" title="Last updated on Jun 27, 2023, 8:08 AM UTC (bb07e2f)">Diff</a>