### PR TITLE
Update DID Method Registry to clarify it's not an endorsement

### DIFF
--- a/index.html
+++ b/index.html
@@ -2866,10 +2866,10 @@ did:foo:21tDAKCERh95uGgKbJNHYp?resource=true
     <p>
 This table summarizes the DID method specifications currently in development. 
 The links will be updated as subsequent Implementer’s Drafts are produced.
-This registry does not act as an endorsement of any particular method or it's
-underlying technologies by W3C, the Decentralized Identifier Working Group,
-or any affiliated members of the W3C. It exists as a method for developers to
-discover various DID methods they wish to implement.
+This registry does not act as an endorsement of any particular DID method or its
+underlying technologies by the W3C, the W3C Decentralized Identifier Working Group,
+or any affiliated members of the W3C. It exists as a mechanism for developers to
+discover various DID methods that they might wish to implement.
     </p>
     <p>
 The normative requirements for DID method specifications can be found in

--- a/index.html
+++ b/index.html
@@ -2864,8 +2864,12 @@ did:foo:21tDAKCERh95uGgKbJNHYp?resource=true
     <h1>DID Methods</h1>
 
     <p>
-This table summarizes the DID method specifications currently in development.
+This table summarizes the DID method specifications currently in development. 
 The links will be updated as subsequent Implementer’s Drafts are produced.
+This registry does not act as an endorsement of any particular method or it's
+underlying technologies by W3C, the Decentralized Identifier Working Group,
+or any affiliated members of the W3C. It exists as a method for developers to
+discover various DID methods they wish to implement.
     </p>
     <p>
 The normative requirements for DID method specifications can be found in


### PR DESCRIPTION
This is necessary because some people believe that listing a method within this registry is somehow an endorsement of the method and it's underlying technology. This clarifies this was not the case, nor was it the goal of the Working group.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/pull/519.html" title="Last updated on Jun 20, 2023, 11:55 AM UTC (ec91ad5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/519/6f42c07...ec91ad5.html" title="Last updated on Jun 20, 2023, 11:55 AM UTC (ec91ad5)">Diff</a>