### PR TITLE
update `secp256k1-2019` w3id.org URLs to be versioned and consistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -1461,7 +1461,7 @@ the Security vocabulary JSON-LD context in the same document.
                 <a href="https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/#ES256K-R">ECDSA Secp256k1 Recovery Signature 2020</a>
               </td>
               <td>
-                <a href="https://w3id.org/security/suites/secp256k1recovery-2020/v1">https://w3id.org/security/suites/secp256k1recovery-2020</a>
+                <a href="https://w3id.org/security/suites/secp256k1recovery-2020/v1">https://w3id.org/security/suites/secp256k1recovery-2020/v1</a>
               </td>
             </tr>
           </tbody>

--- a/index.html
+++ b/index.html
@@ -1189,7 +1189,7 @@ specification</a> for additional details on this topic.
                 <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Ecdsa Secp256k1 Signature 2019</a>
               </td>
               <td>
-                <a href="https://w3id.org/security/suites/secp256k1-2019">https://w3id.org/security/suites/secp256k1-2019</a>
+                <a href="https://w3id.org/security/suites/secp256k1-2019/v1">https://w3id.org/security/suites/secp256k1-2019/v1</a>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
I'm not sure if a small PR like this is a helpful way to contribute; I hope so! Don't think this gets anywhere near a "substantive contributions to specifications" but can do paperwork if needed.

The primary motivation here is that URL https://w3id.org/security/suites/secp256k1-2019 is valid, but does not point to an actual JSON-LD document, just a landing page which links to the v1 document. Most of the other URLs in the registry document point directly to the JSON-LD document.

For the `secp256k1recovery-2020` URL, the href already has `/v1`, but the display URL does not. Seems like they should be consistent like the other URLs.

The background context which led me here was the https://didlint.ownyourdata.eu/validate tool wanting `@context` URLs to match what is in the spec registry document (which for `secp256k1-2019` means no trailing `/v1`), while the `@context` should point directly to a JSON-LD doc, resulting in a contradiction.

Hypothetically it might be most correct to list multiple URLs in the "JSON-LD" columns in this document, both versioned and not.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bnewbold/did-spec-registries/pull/525.html" title="Last updated on Aug 4, 2023, 9:29 PM UTC (92c7ddd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/525/460ba88...bnewbold:92c7ddd.html" title="Last updated on Aug 4, 2023, 9:29 PM UTC (92c7ddd)">Diff</a>