### PR TITLE
Use HTTPS for X25519KeyAgreementKey2019 context.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1418,7 +1418,7 @@ the Security vocabulary JSON-LD context in the same document.
                 <span class="issue">Normative definition pending</span>
               </td>
               <td>
-                <a href="http://w3id.org/security/suites/x25519-2019/v1">http://w3id.org/security/suites/x25519-2019/v1</a>
+                <a href="https://w3id.org/security/suites/x25519-2019/v1">https://w3id.org/security/suites/x25519-2019/v1</a>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
Small "editorial" change to fix the context URL for X25519KeyAgreementKey2019 from `http://` to `https://`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BigBlueHat/did-spec-registries/pull/544.html" title="Last updated on Jul 20, 2024, 9:07 PM UTC (be50673)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/544/305a094...BigBlueHat:be50673.html" title="Last updated on Jul 20, 2024, 9:07 PM UTC (be50673)">Diff</a>