### PR TITLE
Add LinkedVerifiablePresentation service endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -1639,7 +1639,7 @@ in a service object.
 {
   "@context": [
     "https://www.w3.org/ns/did/v1",
-    "https://identity.foundation/contexts/linked-vp/v1"
+    "https://identity.foundation/linked-vp/contexts/v1"
   ],
   "id": "did:example:123",
   "verificationMethod": [{

--- a/index.html
+++ b/index.html
@@ -1615,6 +1615,61 @@ in a service object.
       </section>
 
       <section>
+        <h4>LinkedVerifiablePresentation</h4>
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON-LD</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://identity.foundation/linked-vp/">Linked Verifiable Presentation</a>
+              </td>
+              <td>
+                <a href="https://identity.foundation/linked-vp/contexts/v1">Linked Verifiable Presentation</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example of service and serviceEndpoint properties">
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://identity.foundation/contexts/linked-vp/v1"
+  ],
+  "id": "did:example:123",
+  "verificationMethod": [{
+    "id": "did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
+    "type": "JsonWebKey2020",
+    "controller": "did:example:123",
+    "publicKeyJwk": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ"
+    }
+  }],
+  "service": [
+    {
+      "id": "did:example:123#foo",
+      "type": "LinkedVerifiablePresentation",
+      "serviceEndpoint": ["https://bar.example.com/verifiable-presentation.jsonld"]
+    },
+    {
+      "id": "did:example:123#baz",
+      "type": "LinkedVerifiablePresentation",
+      "serviceEndpoint": "ipfs://bafybeihkoviema7g3gxyt6la7vd5ho32ictqbilu3wnlo3rs7ewhnp7lly/verifiable-presentation.jwt"
+    }
+  ]
+}
+        </pre>
+
+      </section>
+
+      <section>
         <h4>DIDCommMessaging</h4>
         <table class="simple" style="width: 100%;">
           <thead>


### PR DESCRIPTION
The DIF work item Linked Verifiable Presentation defines a new service endpoint for DID documents. Over the past months the spec has been completed and will soon be proposed to advance to the next stage of the specification process.
With this accomplishment, I'd like to register the new service endpoint in this registry.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jceb/did-spec-registries/pull/545.html" title="Last updated on Apr 9, 2024, 1:37 PM UTC (8f41a74)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/545/8cca0a5...jceb:8f41a74.html" title="Last updated on Apr 9, 2024, 1:37 PM UTC (8f41a74)">Diff</a>