### PR TITLE
Fix the Service's structure of DIDCommMessaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -1697,17 +1697,12 @@ in a service object.
       "https://www.w3.org/ns/did/v1",
       "https://didcomm.org/messaging/contexts/v2"
   ],
-  ...
   "type":"DIDCommMessaging",
-  "serviceEndpoint":"http://example.com/path",
-  "accept":[
-      "didcomm/v2",
-      "didcomm/aip2;env=rfc587"
-  ],
-  "routingKeys":[
-      "did:example:somemediator#somekey"
-  ]
-  ...
+  "serviceEndpoint": {
+    "uri": "http://example.com/path",
+    "accept":[ "didcomm/v2", "didcomm/aip2;env=rfc587" ],
+    "routingKeys":[ "did:example:somemediator#somekey" ]
+  }
 }
         </pre>
 


### PR DESCRIPTION
Minor fix on the DID document Service's structure for the type `DIDCommMessaging`.

The `serviceEndpoint` MUST be a json object with the fields `uri`, `accept` and `routingKeys`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/FabioPinheiro/did-spec-registries/pull/548.html" title="Last updated on Jul 20, 2024, 9:11 PM UTC (ec905eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/548/c94348d...FabioPinheiro:ec905eb.html" title="Last updated on Jul 20, 2024, 9:11 PM UTC (ec905eb)">Diff</a>