### PR TITLE
Add did:null method.

### DIFF
--- a/methods/null.json
+++ b/methods/null.json
@@ -1,0 +1,9 @@
+{
+  "name": "null",
+  "status": "registered",
+  "specification": "https://digitalbazaar.github.io/did-method-null-spec/",
+  "contactName": "Digital Bazaar, Inc.",
+  "contactEmail": "support@digitalbazaar.com",
+  "contactWebsite": "https://digitalbazaar.com/",
+  "verifiableDataRegistry": "None"
+}


### PR DESCRIPTION
### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].

### Notes

- Previous PR: https://github.com/w3c/did-spec-registries/pull/431.
- Please also see the previous discussion.
- I've been thinking long and hard for two years about what else to put in the security and privacy sections to make the spec acceptable.  One note was added.  If other edits are needed to explain the intricate complexities of this method about nothing, please provide a hint on what needs to be added.