### PR TITLE
Register `dnsValidationDomain` property

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,14 +617,14 @@ This property has been deprecated, use <a href="#verificationmethod">verificatio
                     href="https://w3id.org/hadids#dnsValidationDomain">High Assurance DIDs with DNS</a>
                 </td>
                 <td>
-                  <a href="https://w3id.org/hadids/v0.5">dnsDomain JSON-LD
+                  <a href="https://w3id.org/hadids/v0.5">dnsValidationDomain JSON-LD
                     Context</a>
                 </td>
               </tr>
             </tbody>
           </table>
         
-          <pre class="example" title="Example of dnsDomain property">
+          <pre class="example" title="Example of dnsValidationDomain property">
 {  
   "dnsValidationDomain": "mydomain.example"
   ...

--- a/index.html
+++ b/index.html
@@ -602,7 +602,7 @@ This property has been deprecated, use <a href="#verificationmethod">verificatio
       </section>
 
         <section>
-          <h4>dnsDomain</h4>
+          <h4>dnsValidationDomain</h4>
           <table class="simple" style="width: 100%;">
             <thead>
               <tr>
@@ -614,10 +614,10 @@ This property has been deprecated, use <a href="#verificationmethod">verificatio
               <tr>
                 <td>
                   <a
-                    href="https://www.ietf.org/archive/id/draft-carter-high-assurance-dids-with-dns-04.html#name-the-dnsdomain-property">High Assurance DIDs with DNS</a>
+                    href="https://w3id.org/hadids#dnsValidationDomain">High Assurance DIDs with DNS</a>
                 </td>
                 <td>
-                  <a href="https://ciralabs.github.io/DnsDomainJsonLd/dns-domain.jsonld">dnsDomain JSON-LD
+                  <a href="https://w3id.org/hadids/v0.5">dnsDomain JSON-LD
                     Context</a>
                 </td>
               </tr>
@@ -626,7 +626,7 @@ This property has been deprecated, use <a href="#verificationmethod">verificatio
         
           <pre class="example" title="Example of dnsDomain property">
 {  
-  "dnsDomain": "mydomain.example"
+  "dnsValidationDomain": "mydomain.example"
   ...
 }</pre>
     </section>

--- a/index.html
+++ b/index.html
@@ -600,6 +600,37 @@ This property has been deprecated, use <a href="#verificationmethod">verificatio
     }</pre>
       
       </section>
+
+        <section>
+          <h4>dnsDomain</h4>
+          <table class="simple" style="width: 100%;">
+            <thead>
+              <tr>
+                <th>Normative Definition</th>
+                <th>JSON-LD</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <a
+                    href="https://www.ietf.org/archive/id/draft-carter-high-assurance-dids-with-dns-04.html#name-the-dnsdomain-property">High Assurance DIDs with DNS</a>
+                </td>
+                <td>
+                  <a href="https://ciralabs.github.io/DnsDomainJsonLd/dns-domain.jsonld">dnsDomain JSON-LD
+                    Context</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        
+          <pre class="example" title="Example of dnsDomain property">
+{  
+  "dnsDomain": "example.com"
+  ...
+}</pre>
+    </section>
+    
     </section>
     <section>
       <h3>Verification relationships</h3>

--- a/index.html
+++ b/index.html
@@ -626,7 +626,7 @@ This property has been deprecated, use <a href="#verificationmethod">verificatio
         
           <pre class="example" title="Example of dnsDomain property">
 {  
-  "dnsDomain": "example.com"
+  "dnsDomain": "mydomain.example"
   ...
 }</pre>
     </section>


### PR DESCRIPTION
The "dnsDomain" property, as outlined in the [High Assurance DIDs with DNS](https://datatracker.ietf.org/doc/draft-carter-high-assurance-dids-with-dns/), helps to establishes a clear and verifiable link between a non web based DID and a DNS domain. This linkage leverages the existing trust infrastructure of the DNS, which is widely recognized and relied upon. By incorporating the "dnsDomain" property, non web based DIDs can benefit from the established trust model of DNS, providing an additional layer of assurance for entities interacting with the DID. It also enables the ability to associate a non web based DID with a DNS based identifier in accordance to the spec, without infringing upon the usage of the "alsoKnownAs" property or "linkedDomains" service type.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/CIRALabs/did-spec-registries/pull/566.html" title="Last updated on Aug 15, 2024, 8:16 PM UTC (4307e8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec-registries/566/dc29fa6...CIRALabs:4307e8f.html" title="Last updated on Aug 15, 2024, 8:16 PM UTC (4307e8f)">Diff</a>