### PR TITLE
did:key method: fix broken link, align authors with spec's list

### DIFF
--- a/methods/key.json
+++ b/methods/key.json
@@ -2,8 +2,8 @@
   "name": "key",
   "status": "registered",
   "verifiableDataRegistry": "Ledger-independent DID method based on public/private key pairs",
-  "contactName": "Rick Astley (thank you for your inspiration), Manu Sporny, Dmitri Zagidulin, Dave Longley, Orie Steele",
+  "contactName": "Manu Sporny, Dmitri Zagidulin, Dave Longley",
   "contactEmail": "",
   "contactWebsite": "",
-  "specification": "https://w3c-ccg.github.io/did-method-key/"
+  "specification": "https://w3c-ccg.github.io/did-key-spec/"
 }


### PR DESCRIPTION
The current link 404s. Also, I almost didn't use this method because of the Rickroll joke, not realizing it was a serious and legitimate method, so I edited the authors to match what's in the most current method spec (at the new link).