### PR TITLE
Add provisional registration for did:me method

### DIFF
--- a/.github/workflows/publish-did-extensions.yml
+++ b/.github/workflows/publish-did-extensions.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   publish-did-extensions:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-did-extensions.yml
+++ b/.github/workflows/publish-did-extensions.yml
@@ -4,9 +4,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
   publish-did-extensions:
     runs-on: ubuntu-latest

--- a/methods/me.json
+++ b/methods/me.json
@@ -1,0 +1,9 @@
+{
+  "name": "me",
+  "status": "provisional",
+  "specification": "https://did-me.org/spec/v1/",
+  "contactName": "did:me Specification Editors",
+  "contactEmail": "",
+  "contactWebsite": "https://did-me.org",
+  "verifiableDataRegistry": "Method-specific signed canonical core chain; optional public directory mirrors"
+}

--- a/methods/me.json
+++ b/methods/me.json
@@ -1,9 +1,9 @@
 {
   "name": "me",
-  "status": "provisional",
+  "status": "registered",
   "specification": "https://did-me.org/spec/v1/",
   "contactName": "did:me Specification Editors",
-  "contactEmail": "",
+  "contactEmail": "maintainers@did-me.org",
   "contactWebsite": "https://did-me.org",
   "verifiableDataRegistry": "Method-specific signed canonical core chain; optional public directory mirrors"
 }


### PR DESCRIPTION
----- DID METHOD REGISTRATION FORM: DELETE EVERYTHING ABOVE THIS LINE ------

### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [ ] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].

---
This PR adds a provisional DID method entry for did:me.

• Method name: me
• Status: provisional
• Specification: https://did-me.org/spec/v1/

did:me defines a lifecycle-controlled DID model with deterministic canonical state validation. Authoritative state is defined by a signed canonical core chain (canonical DAG-CBOR addressed by CID). Method validity is derived from this signed chain rather than a global consensus layer.

The specification includes normative conformance requirements, security considerations, and a versioned JSON-LD context.
