### PR TITLE
Add did:pqie method - Post-Quantum Identity Encryption #667

### DIFF
--- a/methods/pqie.json
+++ b/methods/pqie.json
@@ -1,0 +1,8 @@
+{
+    "name": "pqie",
+    "status": "registered",
+    "specification": "https://dixadholakiya.github.io/pqie-did-spec/",
+    "contactName": "PQIE Research Group",
+    "contactEmail": "dixadholakiya@gmail.com",
+    "verifiableDataRegistry": "Hyperledger Indy + IPFS"
+}

--- a/methods/pqie.json
+++ b/methods/pqie.json
@@ -1,8 +1,10 @@
 {
-    "name": "pqie",
-    "status": "registered",
-    "specification": "https://dixadholakiya.github.io/pqie-did-spec/",
-    "contactName": "PQIE Research Group",
-    "contactEmail": "dixadholakiya@gmail.com",
-    "verifiableDataRegistry": "Hyperledger Indy + IPFS"
+  "name": "pqie",
+  "status": "registered",
+  "verifiableDataRegistry": "Hyperledger Indy / IPFS",
+  "contactName": "Dixa Dholakiya (PQIE Research Group)",
+  "contactEmail": "dixadholakiya@gmail.com",
+  "contactWebsite": "https://dixadholakiya.github.io/pqie-did-spec/",
+  "specification": "https://dixadholakiya.github.io/pqie-did-spec/",
+  "resolverEndpoint": "https://pqie-resolver-production.up.railway.app/1.0/identifiers/"
 }


### PR DESCRIPTION

This PR registers the `did:pqie` DID method (Post-Quantum Identity Encryption) in the W3C DID Method Registry.
### Registration Details:
- **Method Name:** `pqie`
- **Specification:** https://dixadholakiya.github.io/pqie-did-spec/
- **Contact:** dixadholakiya@gmail.com
- **Verifiable Data Registry:** Hyperledger Indy + IPFS
### Checklist:
- [x] Method name is meaningful (`pqie` = Post-Quantum Identity Encryption)
- [x] Specification is linked: https://dixadholakiya.github.io/pqie-did-spec/
- [x] All CRUD operations are explicitly specified (Create, Read/Resolve, Update, Deactivate) within the documentation
- [x] JSON-LD dependencies are accounted for using standard W3C contexts
- [x] No known IP/trademark concerns
- [x] Fully complies with the W3C DID Core specification (https://www.w3.org/TR/did-core/)
