### PR TITLE
Add did:sns DID Method (Solana Name Service)

### DIFF
--- a/methods/sns.json
+++ b/methods/sns.json
@@ -1,0 +1,9 @@
+{
+  "name": "sns",
+  "status": "registered",
+  "verifiableDataRegistry": "Solana",
+  "contactName": "Eduardo Chongkan",
+  "contactEmail": "standards@attestto.com",
+  "contactWebsite": "https://attestto.com",
+  "specification": "https://spec.attestto.com/did-sns/"
+}


### PR DESCRIPTION
### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].

**Specification:** https://spec.attestto.com/did-sns/
**Implementer:** [Attestto](https://attestto.com)
**Verifiable Data Registry:** Solana
**Reference Implementation:** https://github.com/Attestto-com/did-sns-resolver
**IP Affirmation:** https://spec.attestto.com/did-sns/ip-affirmation/
**Implementation Report:** https://spec.attestto.com/did-sns/report/