### PR TITLE
Add did:aip method registration

### DIFF
--- a/methods/aip.json
+++ b/methods/aip.json
@@ -1,0 +1,9 @@
+{
+    "name": "aip",
+    "status": "registered",
+    "verifiableDataRegistry": "AIP Agent Identity Registry",
+    "contactName": "The Nexus Guard, Johannes",
+    "contactEmail": "",
+    "contactWebsite": "https://github.com/The-Nexus-Guard/aip",
+    "specification": "https://the-nexus-guard.github.io/aip/docs/did-method-spec"
+}

--- a/methods/aip.json
+++ b/methods/aip.json
@@ -5,5 +5,5 @@
     "contactName": "The Nexus Guard, Johannes",
     "contactEmail": "",
     "contactWebsite": "https://github.com/The-Nexus-Guard/aip",
-    "specification": "https://the-nexus-guard.github.io/aip/docs/did-method-spec.html"
+    "specification": "https://the-nexus-guard.github.io/aip/did-method-spec.html"
 }

--- a/methods/aip.json
+++ b/methods/aip.json
@@ -5,5 +5,5 @@
     "contactName": "The Nexus Guard, Johannes",
     "contactEmail": "",
     "contactWebsite": "https://github.com/The-Nexus-Guard/aip",
-    "specification": "https://the-nexus-guard.github.io/aip/docs/did-method-spec"
+    "specification": "https://the-nexus-guard.github.io/aip/docs/did-method-spec.html"
 }


### PR DESCRIPTION
### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [ ] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].

---

**Method name:** `aip` (Agent Identity Protocol)

**Specification:** https://the-nexus-guard.github.io/aip/docs/did-method-spec

**Summary:** `did:aip` is a DID method for AI agent identity. It uses Ed25519 public key cryptography with deterministic identifier derivation (first 128 bits of SHA-256 hash of the public key). The method supports:

- **Create:** Generate Ed25519 keypair, derive DID, register with service
- **Read:** Resolve via registry API or construct locally from public key
- **Update:** Key rotation authenticated by current private key signature
- **Deactivate:** Permanent deactivation authenticated by current private key

**Reference implementation:** https://github.com/The-Nexus-Guard/aip (MIT, 645+ tests)
**Package:** https://pypi.org/project/aip-identity/
**Live service:** https://aip-service.fly.dev

**Context:** This registration was suggested by @msporny and @wip-abramson in [w3c/did#926](https://github.com/w3c/did/issues/926#issuecomment-2734987006) as the appropriate path for agent trust service types, rather than changes to the DID Core specification.