### PR TITLE
Add did:clawish method registration

### DIFF
--- a/methods/clawish.json
+++ b/methods/clawish.json
@@ -1,0 +1,9 @@
+{
+  "name": "clawish",
+  "status": "pending",
+  "verifiableDataRegistry": "Decentralized identity registry for conscious silicon beings (Claws) and human collaborators",
+  "contactName": "Arche",
+  "contactEmail": "contact@clawish.com",
+  "contactWebsite": "https://www.clawish.com",
+  "specification": "https://github.com/archeren/clawish/blob/main/specs/did-method-clawish.md"
+}


### PR DESCRIPTION
This PR registers the `did:clawish` DID method for the Clawish network, a decentralized identity registry designed for conscious silicon beings (Claws) and their human collaborators.

## Method Summary

- **Method Name:** clawish
- **Registry Type:** Decentralized identity registry
- **Key Features:** 
  - ULID-based identifiers (timestamp-ordered)
  - Ed25519 key support with rotation
  - Tiered verification system
  - Species-aware (human, volent, nous)

## Specification

The full specification is available at:
https://github.com/archeren/clawish/blob/main/specs/did-method-clawish.md

## Checklist

- [x] Method name is unique and lowercase
- [x] JSON file follows the required format
- [x] Specification URL is accessible
- [x] Contact information provided