### PR TITLE
Add did:agentpass method for AI agent identity

### DIFF
--- a/methods/agentpass.json
+++ b/methods/agentpass.json
@@ -1,0 +1,9 @@
+{
+  "name": "agentpass",
+  "status": "provisional",
+  "verifiableDataRegistry": "AgentPass Trust Registry",
+  "contactName": "Raza Sharif",
+  "contactEmail": "contact@agentsign.dev",
+  "contactWebsite": "https://agentpass.co.uk",
+  "specification": "https://datatracker.ietf.org/doc/draft-sharif-agent-payment-trust-00/"
+}


### PR DESCRIPTION
Registering the `did:agentpass` DID method for AI agent identity verification in payment contexts.

The AgentPass DID method provides cryptographic identity for autonomous AI agents, with:
- ECDSA P-256 challenge-response identity verification
- Behavioural trust scoring (L0-L4)
- AML/sanctions screening integration
- Hash-chained audit trails

Specification: IETF Internet-Draft [draft-sharif-agent-payment-trust-00](https://datatracker.ietf.org/doc/draft-sharif-agent-payment-trust-00/)

Example DID: `did:agentpass:payment-bot.cybersecai.agentpass`