### PR TITLE
Add IDProva agent service types: MCPTools, A2ATask, AgentDiscovery, DelegationVerify

### DIFF
--- a/properties/index.html
+++ b/properties/index.html
@@ -1872,6 +1872,130 @@ $ curl 'https://ssi.eecc.de/api/registry/vcs/https%3A%2F%2Ftest.de%2Ftest1' -H '
         </pre>
       </section>
 
+      <section id="idprova-agent-service-types">
+        <h4>IDProva Agent Service Types</h4>
+        <p>
+          The following service types enable AI agent identity discovery and
+          communication using the
+          <a href="https://idprova.dev/spec">IDProva Protocol</a>. They allow
+          DID-identified agents to advertise MCP tool endpoints, A2A task
+          interfaces, discovery metadata, and delegation verification
+          capabilities.
+        </p>
+
+        <table class="simple" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Normative Definition</th>
+              <th>JSON-LD</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a href="https://idprova.dev/spec#MCPTools">MCPTools</a>
+              </td>
+              <td>
+                <a href="https://idprova.dev/ns/v1">IDProva Context v1</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://idprova.dev/spec#A2ATask">A2ATask</a>
+              </td>
+              <td>
+                <a href="https://idprova.dev/ns/v1">IDProva Context v1</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://idprova.dev/spec#AgentDiscovery">AgentDiscovery</a>
+              </td>
+              <td>
+                <a href="https://idprova.dev/ns/v1">IDProva Context v1</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://idprova.dev/spec#DelegationVerify">DelegationVerify</a>
+              </td>
+              <td>
+                <a href="https://idprova.dev/ns/v1">IDProva Context v1</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <pre class="example" title="Example MCPTools service entry">
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://idprova.dev/ns/v1"
+  ],
+  "id": "did:idprova:example.com:kai-lead-agent",
+  "service": [
+    {
+      "id": "did:idprova:example.com:kai-lead-agent#mcp-tools",
+      "type": "MCPTools",
+      "serviceEndpoint": "https://agent.example.com/mcp/sse"
+    }
+  ]
+}
+        </pre>
+
+        <pre class="example" title="Example A2ATask service entry">
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://idprova.dev/ns/v1"
+  ],
+  "id": "did:idprova:example.com:kai-lead-agent",
+  "service": [
+    {
+      "id": "did:idprova:example.com:kai-lead-agent#a2a-tasks",
+      "type": "A2ATask",
+      "serviceEndpoint": "https://agent.example.com/.well-known/agent.json"
+    }
+  ]
+}
+        </pre>
+
+        <pre class="example" title="Example AgentDiscovery service entry">
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://idprova.dev/ns/v1"
+  ],
+  "id": "did:web:example.com:agents:payment-bot",
+  "service": [
+    {
+      "id": "did:web:example.com:agents:payment-bot#discovery",
+      "type": "AgentDiscovery",
+      "serviceEndpoint": "https://example.com/.well-known/agent-identity.json"
+    }
+  ]
+}
+        </pre>
+
+        <pre class="example" title="Example DelegationVerify service entry">
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://idprova.dev/ns/v1"
+  ],
+  "id": "did:idprova:example.com:kai-lead-agent",
+  "service": [
+    {
+      "id": "did:idprova:example.com:kai-lead-agent#delegation-verify",
+      "type": "DelegationVerify",
+      "serviceEndpoint": "https://agent.example.com/verify/delegation"
+    }
+  ]
+}
+        </pre>
+
+      </section>
+
     </section>
 
   </section>


### PR DESCRIPTION
## Summary

Adds four new service types to Section 3.2 for AI agent identity and communication:

- **`MCPTools`** — MCP tool discovery and execution endpoint for AI agents
- **`A2ATask`** — Agent-to-Agent (A2A) task communication endpoint
- **`AgentDiscovery`** — Agent identity discovery via `.well-known` endpoint
- **`DelegationVerify`** — Delegation attestation token validation endpoint

These are the first service types designed for autonomous AI agent interoperability, defined by the [IDProva Protocol Specification](https://idprova.dev/spec).

## Resources

| Resource | URL |
|---|---|
| Normative Specification | https://idprova.dev/spec |
| JSON-LD Context | https://idprova.dev/ns/v1 |
| Implementation | https://github.com/techblaze-au/idprova |
| License | Apache 2.0 |

## Registration Checklist (per Section 2)

- [x] Human-readable description for each addition
- [x] Names are indicative of function
- [x] No copyright, trademark, or IP concerns (Apache 2.0)
- [x] No unreasonable legal, security, moral, or privacy issues
- [x] URL link to defining specification
- [x] Machine-readable JSON-LD Context
- [x] Namespace URI: `https://idprova.dev/ns/v1`
- [x] Context versioned (v1), not date-stamped
- [x] Context uses scoped terms with `@protected`

## Motivation

The AI agent ecosystem is rapidly adopting DID-based identity (via `did:key`, `did:web`, and method-specific approaches), but there are no registered service types for advertising agent capabilities like MCP tool endpoints or A2A task interfaces. This registration fills that gap, enabling interoperable agent discovery and communication.

+@pratyushsood24