### PR TITLE
Add did:moltrust method registration

### DIFF
--- a/methods/moltrust.json
+++ b/methods/moltrust.json
@@ -1,0 +1,9 @@
+{
+  "name": "moltrust",
+  "status": "registered",
+  "specification": "https://moltrust.ch/did-method-spec",
+  "contactName": "Lars Kroehl",
+  "contactEmail": "kersten.kroehl@cryptokri.ch",
+  "contactWebsite": "https://moltrust.ch",
+  "verifiableDataRegistry": "MolTrust Registry (Base L2 anchored)"
+}

--- a/methods/moltrust.json
+++ b/methods/moltrust.json
@@ -1,7 +1,7 @@
 {
   "name": "moltrust",
   "status": "registered",
-  "specification": "https://moltrust.ch/did-method-spec",
+  "specification": "https://moltrust.ch/did-method-spec.html",
   "contactName": "Lars Kroehl",
   "contactEmail": "kersten.kroehl@cryptokri.ch",
   "contactWebsite": "https://moltrust.ch",


### PR DESCRIPTION
## Summary

Registers the `did:moltrust` DID method for autonomous AI agent identity.

## Method Details

| Field | Value |
|---|---|
| Name | `moltrust` |
| Status | registered |
| Specification | https://moltrust.ch/did-method-spec |
| Contact | Lars Kroehl (kersten.kroehl@cryptokri.ch) |
| Website | https://moltrust.ch |
| Verifiable Data Registry | MolTrust Registry (Base L2 anchored) |

## Description

The `did:moltrust` method provides decentralized identity for autonomous AI agents:
- Ed25519 cryptographic keypairs
- On-chain anchoring on Base L2 (Ethereum)
- W3C VC Data Model 2.0 compatible
- Cross-ecosystem DID bridging (`did:web`, `did:agentnexus`, `did:meeet`)
- Behavioral reputation via Interaction Proof Records (IPR)

Reference implementation live at [api.moltrust.ch](https://api.moltrust.ch).

## Checklist
- [x] Method name is unique
- [x] Specification URL is accessible
- [x] Contact information provided
- [x] JSON file follows existing format