### PR TITLE
Add did:pki DID Method — Bridging National PKI Hierarchies to the DID Ecosystem

### DIFF
--- a/methods/pki.json
+++ b/methods/pki.json
@@ -1,0 +1,9 @@
+{
+  "name": "pki",
+  "status": "registered",
+  "verifiableDataRegistry": "National PKI Trust Registries (X.509)",
+  "contactName": "Eduardo Chongkan",
+  "contactEmail": "open@attestto.com",
+  "contactWebsite": "https://attestto.org",
+  "specification": "https://github.com/Attestto-com/did-pki-spec"
+}


### PR DESCRIPTION
## Peer Review Request — New Method (did:pki)

### Method Name
`pki`

### Summary
`did:pki` is a **read-only** DID method that assigns globally resolvable Decentralized Identifiers to Certificate Authorities (CAs) within national PKI hierarchies. It enables programmatic cross-border signature verification without country-specific integration.

> [!NOTE]
> **The Problem**
>
> Over 100 countries operate sovereign PKI hierarchies for digital signatures. These hierarchies are isolated — a certificate issued by Costa Rica's BCCR is unverifiable in Panama, Spain's FNMT certificates are opaque to Brazilian systems, and no universal resolution protocol exists. Each cross-border verification requires custom tooling: an N-countries x M-verifiers integration problem.

> [!TIP]
> **The Solution**
>
> \`did:pki\` maps X.509 CA certificates to W3C DID Documents through deterministic derivation. Any DID resolver can resolve any national CA's public key — enabling standard chain validation without bundling country-specific root certificates.

### Why a new DID method?

Existing approaches to cross-border PKI interoperability each carry structural limitations:

- **Bilateral trust agreements** (eIDAS Trusted Lists) require diplomatic negotiation per country pair — they don't scale beyond regional blocs
- **Vendor trust programs** (Adobe AATL, browser root stores) create dependency on a private company's inclusion criteria
- **Bridge CAs** (US Federal Bridge) create a single point of failure and political control
- **`did:web` / `did:tdw`** tie identity to DNS — if the domain changes, the DID breaks

`did:pki` derives identity from the **certificate itself** (deterministic, mathematical), not from agreements, vendors, bridge authorities, or DNS. Adding a country means adding its CA certificates — no negotiation required.

See [§9 Interoperability](https://github.com/Attestto-com/did-pki-spec/blob/main/spec/09-interoperability.md) for detailed analysis of how `did:pki` complements (rather than replaces) these existing approaches.

```
did:pki:cr:sinpe:persona-fisica     → Costa Rica BCCR (citizens)
did:pki:es:fnmt:raiz                → Spain FNMT Root CA
did:pki:br:icp:raiz                 → Brazil ICP-Brasil Root CA
did:pki:eu:de:d-trust               → Germany D-Trust (EU QTSP)
did:pki:us:fpki:common-policy       → US Federal PKI
```

### Key Properties
- **Read-only** — DIDs derived from existing certificates, not registered
- **Deterministic** — same certificate → same DID, always, by any implementation
- **Multi-registry** — any party can operate a resolver; no central authority
- **No PII** — CA organizational identity only; never personal data
- **Backward compatible** — adds DID resolution; existing X.509 verification unchanged

### Specification
**Full spec (11 sections):** https://github.com/Attestto-com/did-pki-spec

Covers: syntax (ABNF), DID Document examples, CRUD (read-only), derivation algorithm, trust model, security considerations, privacy considerations, interoperability (ETSI AdES, eIDAS 2.0, GLEIF vLEI, ISO 18013-5, DSS), and references.

### Reference Implementation
- **Resolver:** https://resolver.attestto.com (live, resolves did:pki and did:sns)
- **Repo:** [Attestto-com/attestto-did-resolver](https://github.com/Attestto-com/attestto-did-resolver)
- **Test vectors:** [did-pki-spec/test-vectors/cr.json](https://github.com/Attestto-com/did-pki-spec/tree/main/test-vectors)
- **Universal Resolver PR:** decentralized-identity/universal-resolver#542

### Interoperability
- Integrates with ETSI PAdES/CAdES/XAdES/JAdES signature validation
- Maps EU Trusted Lists (eIDAS) to did:pki DIDs
- Complements GLEIF vLEI (legal entity identity + individual signer verification)
- Compatible with EU Digital Identity Wallets (eIDAS 2.0 / EUDIW)
- Covers 10+ Latin American PKI hierarchies (CR, BR, CO, MX, CL, PE, EC, UY, AR, PA)

### Related
- `did:sns` — PR #674 (same author, different method: alias-anchored identity on Solana)
- `@attestto/trust` — open-source multi-country PKI trust store
- `@attestto/verify` — open-source signature verification web component

### Contact
- **Name:** Eduardo Chongkan
- **Email:** open@attestto.com
- **Organization:** Attestto (https://attestto.org)
