### PR TITLE
add Ciphora DID method

### DIFF
--- a/methods/ciphora.json
+++ b/methods/ciphora.json
@@ -1,0 +1,8 @@
+{
+  "name": "ciphora",
+  "status": "registered",
+  "specification": "https://ciphora.org/did/v1",
+  "contactName": "Ciphora",
+  "contactEmail": "did@ciphora.org",
+  "contactWebsite": "https://ciphora.org"
+}


### PR DESCRIPTION
## DID Method Registration

Adding the Ciphora DID method to the registry.

- Specification: https://ciphora.org/did/v1
- Contact: did@ciphora.org
- Status: registered

As a DID method registrant, I have ensured that my DID method 
registration complies with the following statements:

- [x] The DID Method specification defines the DID Method Syntax.
- [x] The DID Method specification defines the Create, Read, Update, 
and Deactivate DID Method Operations.
- [x] The DID Method specification contains a Security Considerations 
section.
- [x] The DID Method specification contains a Privacy Considerations 
section.
- [x] The JSON file I am submitting has passed all automated 
validation tests.
- [x] The JSON file contains a contactEmail address.