### PR TITLE
Register did:aip DID method

### DIFF
--- a/methods/aip.json
+++ b/methods/aip.json
@@ -1,0 +1,9 @@
+{
+  "name": "aip",
+  "status": "registered",
+  "verifiableDataRegistry": "Solana",
+  "contactName": "AIP Working Group",
+  "contactEmail": "emptylabs0@gmail.com",
+  "contactWebsite": "https://github.com/dr-wilson-empty/aip-beta",
+  "specification": "https://github.com/dr-wilson-empty/aip-beta/blob/feat/agent-identity-standard/standards/did-aip-method-spec.md"
+}

--- a/methods/aip.json
+++ b/methods/aip.json
@@ -5,5 +5,5 @@
   "contactName": "AIP Working Group",
   "contactEmail": "emptylabs0@gmail.com",
   "contactWebsite": "https://github.com/dr-wilson-empty/aip-beta",
-  "specification": "https://github.com/dr-wilson-empty/aip-beta/blob/feat/agent-identity-standard/standards/did-aip-method-spec.md"
+  "specification": "https://github.com/dr-wilson-empty/aip-beta/blob/main/standards/did-aip-method-spec.md"
 }


### PR DESCRIPTION
This PR registers the `did:aip` DID method, a Solana-anchored DID
scheme for autonomous AI agent identity under the Agent Internet
Protocol (AIP).

`did:aip` identifiers take the form `did:aip:{owner_pubkey}:{agent_id}`
and resolve to a Program Derived Address on Solana, owned by the AIP
Agent Registry Program. The on-chain account is deserialised into a
W3C DID Core 1.0 conformant DID Document. No central registry is
involved; resolution requires only a Solana RPC endpoint.

## Specification

https://github.com/dr-wilson-empty/aip-beta/blob/main/standards/did-aip-method-spec.md

The spec uses RFC 2119 keywords throughout and covers method-specific
identifier ABNF, DID Document construction, full CRUD operations,
resolution algorithm, security and privacy considerations, and a
conformance mapping to DID Core 1.0.

## Reference implementation

- On-chain registry program (Solana Devnet, program ID
  `CgchXu2dRV3r9E1YjRhp4kbeLLtv1Xz61yoerJzp1Vbc`):
  https://github.com/dr-wilson-empty/aip-beta/blob/main/programs/aip-escrow/programs/aip-registry/src/lib.rs
- Standalone TypeScript resolver (`@aipagents/did-resolver`, zero anchor
  dependency):
  https://github.com/dr-wilson-empty/aip-beta/tree/main/packages/did-resolver
- Published packages: https://www.npmjs.com/org/aipagents
- Live Devnet round-trip test included in the resolver test suite.

## Contact

GitHub: @dr-wilson-empty
Repository: https://github.com/dr-wilson-empty/aip-beta