### PR TITLE
Register did:tenzro method

### DIFF
--- a/methods/tenzro.json
+++ b/methods/tenzro.json
@@ -1,0 +1,9 @@
+{
+  "name": "tenzro",
+  "status": "registered",
+  "verifiableDataRegistry": "<a href=\"https://tenzro.com\">Tenzro Ledger</a>",
+  "contactName": "Tenzro Engineering",
+  "contactEmail": "eng@tenzro.com",
+  "contactWebsite": "https://tenzro.com",
+  "specification": "https://github.com/tenzro/tenzro-network/blob/main/docs/did-method-tenzro.md"
+}


### PR DESCRIPTION
## Summary

Registers the `did:tenzro` DID method.

## Method overview

`did:tenzro` provides decentralized identifiers anchored on the Tenzro Ledger — an L1 blockchain with HotStuff-2 BFT consensus. The method supports both **human** and **machine** identities (including autonomous agents and delegated-controller agents) with on-chain verifiable credentials and revocation.

DID format:

- `did:tenzro:human:{uuid}` — human identity
- `did:tenzro:machine:{controller_did}:{uuid}` — delegated-controller machine
- `did:tenzro:machine:{uuid}` — autonomous machine

Full specification: <https://github.com/tenzro/did-method-tenzro/blob/main/spec.md>

## Submitter checklist

- [x] The DID method specification is publicly available at a stable URL
- [x] The DID method specification is licensed under a permissive open license (Apache-2.0)
- [x] The DID method specification follows the [W3C DID Core](https://www.w3.org/TR/did-core/) specification
- [x] The DID method has at least one open-source implementation (`tenzro-identity` crate)
- [x] The submitter is prepared to maintain the DID method specification

## Contact

Tenzro Engineering — <eng@tenzro.com>
