### PR TITLE
Add proof.json with proof method details

### DIFF
--- a/methods/proof.json
+++ b/methods/proof.json
@@ -1,0 +1,9 @@
+{
+  "name": "proof",
+  "status": "registered",
+  "verifiableDataRegistry": "Sui Mainnet",
+  "contactName": "PaperProof Labs",
+  "contactEmail": "paperproof.labs@gmail.com",
+  "contactWebsite": "paperproof.wal.app",
+  "specification": "https://github.com/PaperProofLabs/proof/blob/main/doc/en/Proof%20Protocol%20Specification.md"
+}


### PR DESCRIPTION
### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification defines the DID Method Syntax.
- [x] The DID Method specification defines the Create, Read, Update, and Deactivate DID Method Operations.
- [x] The DID Method specification contains a Security Considerations section.
- [x] The DID Method specification contains a Privacy Considerations section.
- [x] The JSON file I am submitting has passed all automated validation tests below.
- [x] The JSON file contains a contactEmail address [OPTIONAL].
- [x] The JSON file contains a verifiableDataRegistry entry [OPTIONAL].

We have also pushed the standalone proof-did-resolver implementation in [PaperProofLabs/proof-did-resolver](https://github.com/PaperProofLabs/proof-did-resolver), and we are now advancing the integration work in [PaperProofLabs/uni-resolver-driver-did-proof](https://github.com/PaperProofLabs/uni-resolver-driver-did-proof) to make `did:proof` a lawful Universal Resolver driver with local driver class loading and `Driver` interface compatibility.