### PR TITLE
Add did:cndomain method registration

### DIFF
--- a/methods/cndomain.json
+++ b/methods/cndomain.json
@@ -1,0 +1,7 @@
+{
+  "name": "cndomain",
+  "status": "registered",
+  "specification": "https://cndomain-dev.github.io/did-method-cndomain/did-cndomain-method-specification-draft.html",
+  "contactName": "did:cndomain Draft Editors",
+  "contactWebsite": "https://github.com/cndomain-dev/did-method-cndomain"
+}


### PR DESCRIPTION
  ### DID Method Registration

  This pull request registers the `did:cndomain` DID method.

  Specification:
  https://cndomain-dev.github.io/did-method-cndomain/did-cndomain-method-specification-draft.html

  Registration JSON:
  `methods/cndomain.json`

  As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

  - [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
  - [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
  - [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
  - [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
  - [ ] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
  - [ ] The JSON file contains a `contactEmail` address [OPTIONAL].
  - [ ] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].