### PR TITLE
Add did:agent — Decentralized identity method for AI agents

### DIFF
--- a/methods/agent.json
+++ b/methods/agent.json
@@ -1,0 +1,7 @@
+{
+  "name": "agent",
+  "status": "provisional",
+  "specification": "https://github.com/m31527/AgentDID/blob/main/docs/did-spec.md",
+  "contact": "https://github.com/m31527/AgentDID/issues",
+  "notes": "Decentralized identity protocol for AI agents and autonomous systems. Extends W3C DID 1.0 with Capability Declaration (pre-declared agent intent), Action Logging (tamper-proof on-chain audit trail), and Reputation Registry (algorithmic trust score 0-100). Non-commercial, MIT licensed. Reference implementation deployed on Ethereum Sepolia testnet at 0x05623871958D6d648953e64B1cdb562Adc28019B. Live demo: https://agentdid.web.app"
+}

--- a/methods/agent.json
+++ b/methods/agent.json
@@ -1,6 +1,6 @@
 {
   "name": "agent",
-  "status": "provisional",
+  "status": "registered",
   "specification": "https://github.com/m31527/AgentDID/blob/main/docs/did-spec.md",
   "contact": "https://github.com/m31527/AgentDID/issues",
   "notes": "Decentralized identity protocol for AI agents and autonomous systems. Extends W3C DID 1.0 with Capability Declaration (pre-declared agent intent), Action Logging (tamper-proof on-chain audit trail), and Reputation Registry (algorithmic trust score 0-100). Non-commercial, MIT licensed. Reference implementation deployed on Ethereum Sepolia testnet at 0x05623871958D6d648953e64B1cdb562Adc28019B. Live demo: https://agentdid.web.app"


### PR DESCRIPTION
## Summary

This PR adds the `did:agent` DID method to the W3C registry.

`did:agent` is an open, non-commercial decentralized identity protocol for AI agents and autonomous systems.

**Specification:** https://github.com/m31527/AgentDID/blob/main/docs/did-spec.md
**Reference Implementation:** https://github.com/m31527/AgentDID
**Live Demo:** https://agentdid.web.app
**Deployed Contract (Sepolia):** `0x05623871958D6d648953e64B1cdb562Adc28019B`

## What makes did:agent unique

Compared to existing DID methods, `did:agent` adds three primitives not found in any registered DID method:

1. **Capability Declaration** — a signed, hash-anchored JSON document committed at registration declaring what actions the agent is and is not permitted to perform.
2. **Action Logging** — every agent action anchors an input/output keccak256 hash on-chain, creating a tamper-proof, community-auditable behavioral record.
3. **Reputation Registry** — an on-chain algorithmic trust score (0–100) computed from action success rate and community anomaly reports, requiring no off-chain oracle.

## W3C DID 1.0 Compliance

The method implements all four CRUD operations (Create, Read, Update, Deactivate) as required by W3C DID 1.0. The specification references the DID Method Rubric v1.0.

## License

The specification is released under CC BY 4.0. The reference implementation is MIT licensed.