### PR TITLE
Add did:foxbook DID method

### DIFF
--- a/methods/foxbook.json
+++ b/methods/foxbook.json
@@ -1,0 +1,9 @@
+{
+  "name": "foxbook",
+  "status": "registered",
+  "verifiableDataRegistry": "Public RFC 9162-shaped Merkle transparency log (single canonical reference deployment at transparency.foxbook.dev; protocol contract supports federation)",
+  "contactName": "Benjamin Bandali",
+  "contactEmail": "hello@foxbook.dev",
+  "contactWebsite": "https://foxbook.dev",
+  "specification": "https://github.com/cloakmaster/foxbook/blob/main/docs/specs/did-foxbook-method.md"
+}


### PR DESCRIPTION
## Summary

Adds `did:foxbook` to the W3C DID method registry. Foxbook is a DID method anchored by an RFC 9162-shaped public Merkle transparency log, addressing verifiable agent identity in A2A and MCP ecosystems.

## Method specification

https://github.com/cloakmaster/foxbook/blob/main/docs/specs/did-foxbook-method.md

## Key properties

- **Method-Specific Identifier**: `did:foxbook:<ulid>` where `<ulid>` is a 26-character ULID in Crockford's Base32 (uppercase). Format regex: `^did:foxbook:[0-7][0-9A-HJKMNP-TV-Z]{25}$`
- **Substrate**: Public, append-only, RFC 9162-shaped Merkle transparency log. Single canonical reference deployment at `transparency.foxbook.dev`; protocol contract is multi-deployment compatible.
- **Cryptography**: Ed25519 signing + recovery keys (separately held); JCS (RFC 8785) canonicalization.
- **Atomic revocation**: revocation appends a leaf to the log + deletes the current claim row in a single transaction. Past inclusion proofs verify forever; the deactivation is atomic by construction.
- **Recovery / signing key separation**: a leaked recovery key permits denial-of-service (revoke + re-claim by attacker under a new DID) but not impersonation; a leaked signing key permits impersonation only until revocation.

## Reference implementation

- Repository: https://github.com/cloakmaster/foxbook (Apache 2.0)
- SDK: `@foxbook/sdk-claim` on npm
- Canonicalization: `canonicalize@2.1.0` (erdtman RFC 8785 reference impl)
- Live deployment: https://transparency.foxbook.dev

## Operational examples

Live `did:foxbook:` registrations in production (resolvable via the canonical deployment):

- `did:foxbook:01KRXTMK3Z20J7V7MMD17W6T59` (leaf 7) — bound to `did:web:api.algovoi.co.uk` and `did:key:z6MkgExzvcpvxrghf4Q3285xqSdenhRZHcP6wc5UvY6VVaz5` (same Ed25519 key); transparency-log inclusion proof at https://transparency.foxbook.dev/leaf/7

## Cross-implementation validation

- Cross-language byte-match test vectors: [schemas/crypto-test-vectors.json](https://github.com/cloakmaster/foxbook/blob/main/schemas/crypto-test-vectors.json) + [schemas/merkle-test-vectors.json](https://github.com/cloakmaster/foxbook/blob/main/schemas/merkle-test-vectors.json)
- The published test vectors are independently reproducible by any conforming RFC 8785 implementation (e.g., `trailofbits/rfc8785.py`); language-agnostic byte-match validation
- Cited as Layer 2 identity primitive (alternative DID method) in:
  - CTEF v0.3.2 substrate-and-primitive layering figure (`agentgraph-co/agentgraph/docs/standards/v0.3.2-layering-figure.md`)
  - State of Agent Security — Q2 2026 (AgentGraph) — §3.8 byte-match table + §4 Partners + §4 Co-signer Perspectives byline

## Trademark posture

The Foxbook trademark is held by Benjamin Bandali. The DID method specification, the reference implementation, and the protocol contracts are Apache 2.0. The trademark is separate (see https://github.com/cloakmaster/foxbook/blob/main/TRADEMARK.md). Nominative use in DID method registry contexts is explicitly permitted.

## Contact

Benjamin Bandali — https://github.com/cloakmaster — hello@foxbook.dev