### PR TITLE
Register did:opena2a method

### DIFF
--- a/methods/opena2a.json
+++ b/methods/opena2a.json
@@ -5,5 +5,5 @@
   "contactName": "Abdel Sy Fane",
   "contactEmail": "",
   "contactWebsite": "",
-  "specification": "https://github.com/opena2a-standards/did-method-opena2a"
+  "specification": "https://github.com/opena2a-standards/did-method-opena2a/blob/main/did-method-opena2a.md"
 }

--- a/methods/opena2a.json
+++ b/methods/opena2a.json
@@ -3,7 +3,5 @@
   "status": "registered",
   "verifiableDataRegistry": "OpenA2A Registry (open-source HTTP-resolvable registry of agents, MCP servers, AI tools, LLMs, skills, publishers, and authorities)",
   "contactName": "Abdel Sy Fane",
-  "contactEmail": "",
-  "contactWebsite": "",
   "specification": "https://github.com/opena2a-standards/did-method-opena2a/blob/main/did-method-opena2a.md"
 }

--- a/methods/opena2a.json
+++ b/methods/opena2a.json
@@ -1,0 +1,9 @@
+{
+  "name": "opena2a",
+  "status": "registered",
+  "verifiableDataRegistry": "OpenA2A Registry (open-source HTTP-resolvable registry of agents, MCP servers, AI tools, LLMs, skills, publishers, and authorities)",
+  "contactName": "Abdel Sy Fane",
+  "contactEmail": "",
+  "contactWebsite": "",
+  "specification": "https://github.com/opena2a-standards/did-method-opena2a"
+}


### PR DESCRIPTION
## Summary

Registers the `did:opena2a` DID method in the W3C DID Extensions registry.

`did:opena2a` is the DID method used by the OpenA2A Registry, an open-source HTTP-resolvable registry of agents, MCP servers, AI tools, LLMs, skills, publishers, and authorities, and by three independent OpenA2A conformance suites (ATX, ATP, AIP) that publish byte-stable test vectors.

```
did:opena2a:registry:opena2a.org
did:opena2a:authority:opena2a.org
did:opena2a:agent:agent_conformance_test_001
did:opena2a:mcp_server:@modelcontextprotocol/server-filesystem
```

## Method specification

The full specification is published at:

- <https://github.com/opena2a-standards/did-method-opena2a>
- spec file: <https://github.com/opena2a-standards/did-method-opena2a/blob/main/did-method-opena2a.md>

The specification documents the `did:opena2a:<resource-type>:<resource-id>[#fragment]` syntax (ABNF), all four method operations (Create, Read, Update, Deactivate) as backed by the OpenA2A Registry HTTP API, the DID Document shape (Ed25519 verification key + service endpoints for trust lookup, signed trust proofs, trust badges), and security and privacy considerations.

The specification is honest about its trust model: `did:opena2a` is a registry-mediated DID method, not a fully decentralized one in the sense of `did:peer` or `did:key`. Federation is permitted by the design but not required, and the trust root is the OpenA2A Registry's Ed25519 signing key, rotated through a documented overlap window.

## Status request

This entry requests `"status": "registered"` based on three independent conformance suites (ATX, ATP, AIP) that exercise the method in production with byte-stable fixtures and reference verifiers (Go, Rust, TypeScript, Python). If registry editors prefer `"provisional"` for an initial submission, please indicate and I will update the entry accordingly.

## Checklist

- [x] The DID method is documented in a specification at a stable URL.
- [x] The specification covers method-specific syntax, all four operations, security considerations, and privacy considerations.
- [x] The submission is licensed appropriately (Apache-2.0 for the specification text; the registry entry itself is governed by the W3C Patent Policy and Document License).
- [ ] Non-member patent licensing commitment is being filed separately with W3C IPR (OpenA2A is not currently a W3C Working Group member).
- [x] Reference implementations exist and are linked from the specification.

## Reference implementation

Open source under Apache-2.0:

- OpenA2A Registry (Go): <https://github.com/opena2a-org/opena2a-registry>
  - DID resolution: `internal/application/did_service.go`
  - DID handler: `internal/interfaces/http/handlers/did_handler.go`
  - Routes: `GET /api/v1/did/*`, `GET /.well-known/opena2a`
- Live resolver: <https://api.oa2a.org/api/v1/did/did:opena2a:registry:opena2a.org>
- Discovery document: <https://api.oa2a.org/.well-known/opena2a>

## Conformance evidence

- ATX (Agent Trust Cross-Verification): <https://github.com/opena2a-standards/atx-conformance>
- ATP (Agent Trust Protocol): <https://github.com/opena2a-standards/atp-conformance>
- AIP (Agent Identity Protocol): <https://github.com/opena2a-standards/aip-conformance>
