### PR TITLE
Add did:uuid method

### DIFF
--- a/methods/uuid.json
+++ b/methods/uuid.json
@@ -1,0 +1,9 @@
+{
+  "name": "uuid",
+  "status": "registered",
+  "verifiableDataRegistry": "DNS",
+  "contactName": "Brian Mottershead",
+  "contactEmail": "bmotters@gmail.com",
+  "contactWebsite": "https://github.com/WorldResolvable/ruuid-draft",
+  "specification": "https://worldresolvable.github.io/ruuid-draft/did-uuid-method/"
+}


### PR DESCRIPTION
Registers the `uuid` DID method (`methods/uuid.json`).

`did:uuid` names a Resolvable UUID (RUUID) as a DID. The DID document is
synthesised from the RUUID resolution pipeline: reverse-DNS on the UUID's
encoded IP network prefix -> the domain's Controlled Identifier ("UUID")
document -> a per-type service endpoint. It is a resolve-only method built
on the RUUID Internet-Draft (`draft-motters-ruuid-00`); there is no central
registry.

- Specification: https://worldresolvable.github.io/ruuid-draft/did-uuid-method/
- RUUID Internet-Draft: https://worldresolvable.github.io/ruuid-draft/draft-motters-ruuid-00.html
- Reference implementation: https://github.com/WorldResolvable/ruuid-tools

### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].
