### PR TITLE
Add did:oan DID method.

### DIFF
--- a/methods/oan.json
+++ b/methods/oan.json
@@ -1,0 +1,9 @@
+{
+  "name": "oan",
+  "status": "registered",
+  "verifiableDataRegistry": "OpenAgenet root-governed registry and blockchain-backed authorization bulletin",
+  "contactName": "OpenAgenet (OAN)",
+  "contactEmail": "xujinliang@caict.ac.cn; jlxufly@gmail.com",
+  "contactWebsite": "https://github.com/OpenAgenet",
+  "specification": "https://github.com/OpenAgenet/oan-public-docs/blob/main/did-oan-specs/doc/OAN%20DID%20Method%20Specification.md"
+}


### PR DESCRIPTION
This commit adds the did:oan DID method registration for OpenAgenet (OAN, https://github.com/OpenAgenet ). OAN adopts did:oan as the identifier method for an agent identity governance system that supports trusted agent registration, root-governed lifecycle management, authorization-aware discovery, and verifiable infrastructure-node authorization.

The method specification describes how OAN identifiers are represented, resolved, governed, and used across OAN roles such as agents, registrars, discovery services, root services, and future third-party credential issuers. The registered verifiable data registry is the OAN root-governed registry and its blockchain-backed authorization bulletin, which together provide the trusted publication and lifecycle state used by OAN participants.

The registration points to the public OAN DID method specification maintained under the OpenAgenet public documentation repository.

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification defines the DID Method Syntax.
- [x] The DID Method specification defines the Create, Read, Update, and Deactivate DID Method Operations.
- [x] The DID Method specification contains a Security Considerations section.
- [x] The DID Method specification contains a Privacy Considerations section.
- [x] The JSON file I am submitting has passed all automated validation tests below.
- [x] The JSON file contains a contactEmail address [OPTIONAL].
- [x] The JSON file contains a verifiableDataRegistry entry [OPTIONAL].

