### PR TITLE
Register did:cid method

### DIFF
--- a/methods/cid.json
+++ b/methods/cid.json
@@ -1,0 +1,9 @@
+{
+  "name": "cid",
+  "status": "registered",
+  "specification": "https://archon.technology/specs",
+  "contactName": "Christian Saucier",
+  "contactEmail": "flaxscrip@pm.me",
+  "contactWebsite": "https://github.com/flaxscrip",
+  "verifiableDataRegistry": "IPFS (DID creation); pluggable update registries: Bitcoin, Ethereum, Zcash, Solana, Filecoin, Hyperswarm"
+}


### PR DESCRIPTION
## DID Method Registration: \`did:cid\`

The \`did:cid\` method uses IPFS Content Identifiers (CIDv1) as method-specific identifiers, anchoring DID creation to IPFS and recording updates on a pluggable registry (Bitcoin, Ethereum, Zcash, Solana, Filecoin, or Hyperswarm).

### Checklist

- [x] The DID Method specification defines the DID Method Syntax
- [x] The DID Method specification defines Create, Read, Update, and Deactivate operations
- [x] The DID Method specification contains a Security Considerations section
- [x] The DID Method specification contains a Privacy Considerations section
- [x] The JSON file has passed all automated validation tests
- [x] The JSON file contains a `contactEmail` address
- [x] The JSON file contains a `verifiableDataRegistry` entry