### PR TITLE
Register did:x509 method

### DIFF
--- a/methods/x509.json
+++ b/methods/x509.json
@@ -1,0 +1,9 @@
+{
+  "name": "x509",
+  "status": "registered",
+  "specification": "https://github.com/microsoft/did-x509/blob/main/specification.md",
+  "contactName": "Max Tropets",
+  "contactEmail": "maxtropets@microsoft.com",
+  "contactWebsite": "https://www.microsoft.com",
+  "verifiableDataRegistry": "No persistent registry; resolution uses the DID string and x509chain resolution option"
+}


### PR DESCRIPTION
This PR registers the [DID x509 method](https://github.com/microsoft/did-x509/blob/main/specification.md) method, which bridges existing X.509 certificate infrastructure with DID-based identifiers without introducing a new registry. A did:x509 identifier binds a certificate authority fingerprint to one or more predicates over the leaf certificate, such as subject fields, SAN values, EKUs, or Fulcio issuer data. This lets applications refer to a certificate-backed logical identity using a compact DID string instead of embedding certificate-chain details directly into issuer policies.

Resolution is a local operation: the resolver receives the DID plus an x509chain resolution option containing the certificate chain, validates the chain, checks that the pinned CA fingerprint and predicates match, and derives a DID Document from the leaf certificate public key. The method is intended for scenarios where messages already carry or reference X.509 chains, such as signed envelopes, credentials, transparency logs, or policy evaluation, while leaving the final trust decision to the relying party’s normal CA and application policy.

### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].