### PR TITLE
Add did:ixo DID method

### DIFF
--- a/methods/ixo.json
+++ b/methods/ixo.json
@@ -1,0 +1,9 @@
+{
+  "name": "ixo",
+  "status": "registered",
+  "verifiableDataRegistry": "IXO Impact Hub",
+  "contactName": "IXO Foundation",
+  "contactEmail": "earthprogram@ixo.world",
+  "contactWebsite": "https://www.ixo.world/",
+  "specification": "https://github.com/ixofoundation/ixo-did-method/blob/main/README.md"
+}


### PR DESCRIPTION
### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].

Additional implementation evidence:

- `ixo-did-resolver` latest release: https://github.com/ixofoundation/ixo-did-resolver/releases/tag/v0.1.2
- DID-specific JSON-LD context: https://w3id.org/ixo/ns/did/v1
- W3C DID Test Suite fork and implementation evidence: https://github.com/ixoworld/did-test-suite/tree/ixo
- Test-suite result recorded by IXO-2335: 173/173 normative tests passing across DID identifier, DID production, DID Core properties, and DID resolution suites.