### PR TITLE
Add did:artifact method registration

### DIFF
--- a/methods/artifact.json
+++ b/methods/artifact.json
@@ -1,0 +1,9 @@
+{
+  "name": "artifact",
+  "status": "registered",
+  "specification": "https://oma3dao.github.io/omatrust-docs/specification/did-artifact-method-spec.html",
+  "contactName": "OMA3",
+  "contactEmail": "info@oma3.org",
+  "contactWebsite": "https://www.oma3.org/",
+  "verifiableDataRegistry": "None (generative; identifier derived from content hash)"
+}


### PR DESCRIPTION
### DID Method Registration

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].

---

**Method name:** `artifact`

**Specification:** https://oma3dao.github.io/omatrust-docs/specification/did-artifact-method-spec.html

**Summary:** `did:artifact` identifies immutable artifacts (files, packages, container images, proof manifests) by their content hash. The method-specific identifier is a CIDv1 encoding of the artifact's SHA-256 digest. Resolution is generative and offline — no registry, ledger, or network interaction is required. The method provides referential identity only; trust assertions are expressed by external attestations referencing the DID.

**Organization:** [OMA3](https://www.oma3.org/)