### PR TITLE
Register did:dfos method

### DIFF
--- a/methods/dfos.json
+++ b/methods/dfos.json
@@ -1,0 +1,9 @@
+{
+  "name": "dfos",
+  "status": "registered",
+  "verifiableDataRegistry": "None (self-certifying; identifiers are derived deterministically from a cryptographically signed genesis operation)",
+  "contactName": "Brandon Valosek",
+  "contactEmail": "brandon@dfos.com",
+  "contactWebsite": "https://github.com/metalabel/dfos",
+  "specification": "https://protocol.dfos.com/did-method"
+}


### PR DESCRIPTION
### DID Method Registration

Adds `methods/dfos.json`, registering the `did:dfos` method. `did:dfos` identifiers are self-certifying: they are derived deterministically from the genesis operation of a cryptographically signed identity chain, with no external verifiable data registry, blockchain, or resolution service. Specification: https://protocol.dfos.com/did-method. Reference implementations (TypeScript and Go, with cross-language test vectors) are MIT-licensed at https://github.com/metalabel/dfos.

As a DID method registrant, I have ensured that my DID method registration complies with the following statements:

- [x] The DID Method specification [defines the DID Method Syntax](https://w3c.github.io/did-core/#method-syntax).
- [x] The DID Method specification [defines the Create, Read, Update, and Deactivate DID Method Operations](https://w3c.github.io/did-core/#method-operations).
- [x] The DID Method specification [contains a Security Considerations section](https://w3c.github.io/did-core/#security-requirements).
- [x] The DID Method specification [contains a Privacy Considerations section](https://w3c.github.io/did-core/#privacy-requirements).
- [x] The JSON file I am submitting has [passed all automated validation tests below](#partial-pull-merging).
- [x] The JSON file contains a `contactEmail` address [OPTIONAL].
- [x] The JSON file contains a `verifiableDataRegistry` entry [OPTIONAL].
