### PR TITLE
Register did:uuaid method

### DIFF
--- a/methods/uuaid.json
+++ b/methods/uuaid.json
@@ -1,0 +1,9 @@
+{
+  "name": "uuaid",
+  "status": "registered",
+  "verifiableDataRegistry": "UUAID Registry — hash-chained ledger with Merkle roots anchored on Polygon mainnet (eip155:137)",
+  "contactName": "UUAID Foundation",
+  "contactEmail": "madanksamy@gmail.com",
+  "contactWebsite": "https://uuaid.org",
+  "specification": "https://github.com/uuaid/spec/blob/main/did-method-uuaid.md"
+}


### PR DESCRIPTION
Registers the `did:uuaid` DID method.

- **Method name:** `uuaid`
- **Specification:** https://github.com/uuaid/spec/blob/main/did-method-uuaid.md — covers method syntax (full ABNF, two identifier profiles), all four CRUD operations, and substantive Security & Privacy Considerations.
- **Verifiable data registry:** the UUAID registry — an append-only, hash-chained event ledger whose Merkle roots are anchored on Polygon mainnet (eip155:137); public resolution at `api.uuaid.org` with third-party-verifiable Merkle inclusion receipts.
- **Underlying identifier:** UUAID (Universal Unique Agent Identifier) — persistent identifiers for autonomous AI agents and associated objects, per the open Universal Agent Protocol (UAP v1, ratified as IAASO-0001 by the International Autonomous Agents Standards Organization).

Contact: UUAID Foundation — https://uuaid.org