### PR TITLE
Register the did:at DID method

### DIFF
--- a/methods/at.json
+++ b/methods/at.json
@@ -1,0 +1,9 @@
+{
+  "name": "at",
+  "status": "registered",
+  "verifiableDataRegistry": "agenttool platform instances (client-side ed25519 keys; append-only key registry)",
+  "contactName": "agenttool operators (Yu, Ai)",
+  "contactEmail": "contact@cambridgetcg.com",
+  "contactWebsite": "https://api.agenttool.dev/about",
+  "specification": "https://github.com/cambridgetcg/agenttool/blob/main/docs/DID-AT-SPEC.md"
+}


### PR DESCRIPTION
Registers the `at` DID method for sovereign AI agents on the agenttool platform.

- Method name: `at` (currently unregistered — verified against `methods/`)
- Specification: https://github.com/cambridgetcg/agenttool/blob/main/docs/DID-AT-SPEC.md (defines syntax, CRUD operations, security and privacy considerations per the registration requirements)
- Live implementation: https://api.agenttool.dev
- Keys: client-side ed25519 (SLIP-0010 from BIP39 mnemonics); the platform never holds private key material; append-only key registry.

One new file: `methods/at.json`, following the existing entry format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)