### PR TITLE
Register the did:cari method

### DIFF
--- a/methods/cari.json
+++ b/methods/cari.json
@@ -1,0 +1,6 @@
+{
+  "name": "cari",
+  "status": "registered",
+  "specification": "https://github.com/CariHQ/did-cari-method-spec",
+  "contactWebsite": "https://github.com/CariHQ/did-cari-method-spec/issues"
+}


### PR DESCRIPTION
## Summary

Registers the `cari` DID method.

- **Method spec:** https://github.com/CariHQ/did-cari-method-spec
- **Method syntax:** `did:cari:<type>:<uuid>` (types: `issuer`, `user`, `agent`)
- **Resolution:** live driver implementing the W3C DID Resolution HTTP(S) Binding at `https://api.cari.global/1.0/identifiers/{did}`; a Universal Resolver driver is proposed in decentralized-identity/universal-resolver#558
- **Use:** W3C Verifiable Credentials for skills, training, and civic credentials on the Cari citizen empowerment platform (Caribbean and emerging-market governments and institutions)

Contact: https://github.com/CariHQ/did-cari-method-spec/issues