### PR TITLE
Add contact and verifiable data registry fields to did:cari entry

### DIFF
--- a/methods/cari.json
+++ b/methods/cari.json
@@ -1,6 +1,9 @@
 {
   "name": "cari",
   "status": "registered",
-  "specification": "https://github.com/CariHQ/did-cari-method-spec",
-  "contactWebsite": "https://github.com/CariHQ/did-cari-method-spec/issues"
+  "verifiableDataRegistry": "Cari platform DID registry (HTTPS DID Resolution binding)",
+  "contactName": "Kenroy George",
+  "contactEmail": "hello@cari.global",
+  "contactWebsite": "https://cari.global",
+  "specification": "https://github.com/CariHQ/did-cari-method-spec"
 }


### PR DESCRIPTION
Follow-up to #735 (merged). During that review, @swcurran and @ottomorac noted the optional registry fields were missing. This adds them to `methods/cari.json`:

- `contactName`: Kenroy George
- `contactEmail`: hello@cari.global
- `contactWebsite`: https://cari.global
- `verifiableDataRegistry`: Cari platform DID registry (HTTPS DID Resolution binding)

The did:cari specification has also been expanded (DID Document example, an explicit Verifiable Data Registry section, and a CC BY 4.0 license) at https://github.com/CariHQ/did-cari-method-spec per the same feedback.

No change to `name`, `status`, or `specification`.